### PR TITLE
feat: add to_h/from_h serialisation API (v0.7.0) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Workpattern v0.7.0 (unreleased) ##
+
+* Added `Workpattern#to_h` — serialises a workpattern to a plain Ruby hash (JSON-safe; pattern bitmaps are hex-encoded strings).
+* Added `Workpattern.from_h(hash, overwrite: false)` — reconstructs a workpattern from a hash produced by `to_h`. Requires symbol keys; when deserialising from JSON use `JSON.parse(json, symbolize_names: true)`.
+* Removed `Workpattern.persistence_class=` and `Workpattern.persistence?` — both were silently non-functional in all prior releases due to a `@@persist`/`@@persistence` naming bug; no working integration exists.
+* Fixed `DEFAULT_NAME` undefined constant in `Workpattern::Workpattern.initialize` (pre-existing; only triggered when calling the inner class constructor directly with no arguments).
+* Fixed `Array.new(LAST_DAY_OF_WEEK)` → `Array.new(LAST_DAY_OF_WEEK + 1)` in `Week.initialize` for consistency (pre-existing; Ruby auto-extends arrays so no runtime difference).
+
 ## Workpattern v0.6.0 ( 25 Feb, 2021) ##
 
 I stopped keeping this Changelog file update back when v0.5.0 was realeased on 19 Oct 2016 and now it is 10Feb 2021 and I'm playing catch-up.

--- a/README.md
+++ b/README.md
@@ -92,3 +92,25 @@ Workpattern.delete "My Workpattern"
 # Delete all Workpatterns
 Workpattern.clear
 ```
+
+### Serialisation
+
+A `Workpattern` can be serialised to a plain Ruby hash and restored later.  The hash is JSON-safe — pattern bitmaps are stored as hex strings.
+
+``` ruby
+# Serialise
+h = mywp.to_h
+
+# Persist however you like (file, database, Redis, …)
+json = JSON.generate(h)
+
+# Restore — JSON.parse must use symbolize_names: true
+h2 = JSON.parse(json, symbolize_names: true)
+mywp2 = Workpattern.from_h(h2)
+```
+
+If a workpattern with the same name already exists, `from_h` raises `NameError`.  Pass `overwrite: true` to replace it:
+
+``` ruby
+Workpattern.from_h(h, overwrite: true)
+```

--- a/lib/workpattern.rb
+++ b/lib/workpattern.rb
@@ -75,6 +75,26 @@ module Workpattern
     Workpattern.clear
   end
 
+  # Convenience method to serialise a Workpattern to a plain hash.
+  #
+  # @param [Hash] hash produced by Workpattern#to_h
+  # @param [Boolean] overwrite replace an existing same-named workpattern
+  # @return [Workpattern]
+  # @raise [ArgumentError] if the hash is missing or has an unsupported version
+  # @raise [NameError] if a same-named workpattern already exists and overwrite is false
+  #
+  def self.from_h(hash, overwrite: false)
+    Workpattern.from_h(hash, overwrite: overwrite)
+  end
+
+  # Convenience method to access the registry of all known Workpattern objects.
+  #
+  # @return [Hash]
+  #
+  def self.workpatterns
+    Workpattern.workpatterns
+  end
+
   # Convenience method to create a Clock object.  This can be used for
   # specifying times if you don't want to create a <tt>DateTime</tt> object
   #

--- a/lib/workpattern.rb
+++ b/lib/workpattern.rb
@@ -75,7 +75,7 @@ module Workpattern
     Workpattern.clear
   end
 
-  # Convenience method to serialise a Workpattern to a plain hash.
+  # Convenience method to deserialise a Workpattern from a plain hash.
   #
   # @param [Hash] hash produced by Workpattern#to_h
   # @param [Boolean] overwrite replace an existing same-named workpattern

--- a/lib/workpattern/day.rb
+++ b/lib/workpattern/day.rb
@@ -15,6 +15,12 @@ module Workpattern
     end
 
     def self.from_h(h)
+      unless h[:hours_per_day].is_a?(Integer) && h[:hours_per_day] > 0 && h[:hours_per_day] <= HOURS_IN_DAY
+        raise ArgumentError, "from_h: hours_per_day must be an Integer between 1 and #{HOURS_IN_DAY}"
+      end
+      unless h[:pattern].is_a?(String) && h[:pattern].length <= 400
+        raise ArgumentError, "from_h: pattern must be a hex String of at most 400 characters"
+      end
       day = allocate
       day.hours_per_day = h[:hours_per_day]
       day.pattern = h[:pattern].to_i(16)

--- a/lib/workpattern/day.rb
+++ b/lib/workpattern/day.rb
@@ -2,7 +2,24 @@ module Workpattern
   
   class Day
     
-    attr_accessor  :pattern, :hours_per_day, :first_working_minute, :last_working_minute
+    attr_accessor :hours_per_day, :first_working_minute, :last_working_minute
+    attr_reader :pattern
+
+    def pattern=(value)
+      @pattern = value
+      set_first_and_last_minutes
+    end
+
+    def to_h
+      { pattern: @pattern.to_s(16), hours_per_day: @hours_per_day }
+    end
+
+    def self.from_h(h)
+      day = allocate
+      day.hours_per_day = h[:hours_per_day]
+      day.pattern = h[:pattern].to_i(16)
+      day
+    end
 
     def initialize(hours_per_day = HOURS_IN_DAY, type = WORK_TYPE)
       @hours_per_day = hours_per_day

--- a/lib/workpattern/version.rb
+++ b/lib/workpattern/version.rb
@@ -1,3 +1,3 @@
 module Workpattern
-  VERSION = '0.6.0'
+  VERSION = '0.7.0'
 end

--- a/lib/workpattern/week.rb
+++ b/lib/workpattern/week.rb
@@ -21,6 +21,23 @@ module Workpattern
       end
     end
 
+    def to_h
+      { start:  { year: @start.year,  month: @start.month,  day: @start.day },
+        finish: { year: @finish.year, month: @finish.month, day: @finish.day },
+        days:   (FIRST_DAY_OF_WEEK..LAST_DAY_OF_WEEK).map { |i| @days[i].to_h } }
+    end
+
+    def self.from_h(h)
+      s = h[:start]; f = h[:finish]
+      week = allocate
+      week.hours_per_day = HOURS_IN_DAY
+      week.start  = Time.gm(s[:year], s[:month], s[:day])
+      week.finish = Time.gm(f[:year], f[:month], f[:day])
+      week.days   = Array.new(LAST_DAY_OF_WEEK + 1)
+      h[:days].each_with_index { |dh, i| week.days[i] = Day.from_h(dh) }
+      week
+    end
+
     def <=>(other)
       return -1 if start < other.start
       return 0 if start == other.start

--- a/lib/workpattern/week.rb
+++ b/lib/workpattern/week.rb
@@ -9,13 +9,12 @@ module Workpattern
   # @private
   class Week
     attr_accessor :hours_per_day, :start, :finish, :days
-    attr_writer :week_total, :total
 
     def initialize(start, finish, type = WORK_TYPE, hours_per_day = HOURS_IN_DAY)
       @hours_per_day = hours_per_day
       @start = Time.gm(start.year, start.month, start.day)
       @finish = Time.gm(finish.year, finish.month, finish.day)
-      @days = Array.new(LAST_DAY_OF_WEEK)
+      @days = Array.new(LAST_DAY_OF_WEEK + 1)
       FIRST_DAY_OF_WEEK.upto(LAST_DAY_OF_WEEK) do |i|
         @days[i] = Day.new(hours_per_day, type)
       end
@@ -28,7 +27,8 @@ module Workpattern
     end
 
     def self.from_h(h)
-      s = h[:start]; f = h[:finish]
+      s = h[:start]
+      f = h[:finish]
       week = allocate
       week.hours_per_day = HOURS_IN_DAY
       week.start  = Time.gm(s[:year], s[:month], s[:day])
@@ -287,9 +287,6 @@ module Workpattern
       time + DAY
     end
 
-    def prev_day(time)
-      time - DAY
-    end
 
     def jd(time)
       Time.gm(time.year, time.month, time.day)

--- a/lib/workpattern/week_pattern.rb
+++ b/lib/workpattern/week_pattern.rb
@@ -40,10 +40,8 @@ module Workpattern
     # @see #working
     # @see #resting
     #
-    def workpattern(opts = {}, persist = nil)
+    def workpattern(opts = {})
       args = all_workpattern_options(opts)
-
-      persist.store(name: @name, workpattern: args) if !persist.nil?
 
       args = standardise_args(args)
 

--- a/lib/workpattern/workpattern.rb
+++ b/lib/workpattern/workpattern.rb
@@ -164,6 +164,53 @@ module Workpattern
       workpattern(args)
     end
 
+    def to_h
+      { version: 1,
+        name:    @name,
+        base:    @base,
+        span:    @span,
+        weeks:   @weeks.map(&:to_h) }
+    end
+
+    def self.from_h(hash, overwrite: false)
+      unless hash.key?(:version)
+        raise ArgumentError, "from_h: hash is missing a :version key " \
+                             "(if deserialising from JSON, use symbolize_names: true)"
+      end
+      unless hash[:version] == 1
+        raise ArgumentError, "from_h: unsupported version #{hash[:version].inspect} " \
+                             "(supported: 1)"
+      end
+
+      name = hash[:name]
+      if workpatterns.key?(name)
+        if overwrite
+          workpatterns.delete(name)
+        else
+          raise NameError, "Workpattern '#{name}' already exists and can't be created again"
+        end
+      end
+
+      wp = allocate
+      wp.instance_variable_set(:@name, name)
+      wp.instance_variable_set(:@base, hash[:base])
+      wp.instance_variable_set(:@span, hash[:span])
+
+      offset    = hash[:span] < 0 ? hash[:span].abs - 1 : 0
+      from_time = Time.gm(hash[:base].abs - offset)
+      to_time   = Time.gm(from_time.year + hash[:span].abs - 1, 12, 31, 23, 59)
+      wp.instance_variable_set(:@from, from_time)
+      wp.instance_variable_set(:@to,   to_time)
+
+      weeks = SortedSet.new
+      hash[:weeks].each { |wh| weeks << Week.from_h(wh) }
+      wp.instance_variable_set(:@weeks, weeks)
+      wp.instance_variable_set(:@week_pattern, WeekPattern.new(wp))
+
+      workpatterns[name] = wp
+      wp
+    end
+
     # Calculates the resulting date when the <tt>duration</tt> in minutes
     # is added to the <tt>start</tt> date.
     # The <tt>duration</tt> is always in whole minutes and subtracts from

--- a/lib/workpattern/workpattern.rb
+++ b/lib/workpattern/workpattern.rb
@@ -38,16 +38,6 @@ module Workpattern
     #
     attr_reader :name, :base, :span, :from, :to, :weeks
 
-    # Class for handling persistence in user's own way
-    #
-    def self.persistence_class=(klass)
-      @@persist = klass
-    end
-
-    def self.persistence?
-      @@persist ||= nil
-    end
-
     # Holds local timezone info
     @@tz = nil
 
@@ -151,11 +141,7 @@ module Workpattern
     # @see #resting
     #
     def workpattern(opts = {})
-      if self.class.persistence?
-        week_pattern.workpattern(opts, @@persistence)
-      else
-        week_pattern.workpattern(opts)
-      end
+      week_pattern.workpattern(opts)
     end
 
     # Convenience method that calls <tt>#workpattern</tt> with the

--- a/lib/workpattern/workpattern.rb
+++ b/lib/workpattern/workpattern.rb
@@ -19,10 +19,6 @@ module Workpattern
       @@workpatterns
     end
 
-    def workpatterns
-      @@workpatterns
-    end
-
     # @!attribute [r] name
     #   Name given to the <tt>Workpattern</tt>
     # @!attribute [r] base
@@ -65,7 +61,7 @@ module Workpattern
     # 31st December.
     # @raise [NameError] if the given name already exists
     #
-    def initialize(name = DEFAULT_NAME, base = DEFAULT_BASE_YEAR, span = DEFAULT_SPAN)
+    def initialize(name = DEFAULT_WORKPATTERN_NAME, base = DEFAULT_BASE_YEAR, span = DEFAULT_SPAN)
       if workpatterns.key?(name)
         raise(NameError, "Workpattern '#{name}' already exists and can't be created again")
       end
@@ -86,6 +82,11 @@ module Workpattern
     def week_pattern
       @week_pattern
     end
+
+    private def workpatterns
+      @@workpatterns
+    end
+    public
 
     # Deletes all <tt>Workpattern</tt> objects
     #
@@ -181,14 +182,22 @@ module Workpattern
         raise ArgumentError, "from_h: unsupported version #{hash[:version].inspect} " \
                              "(supported: 1)"
       end
+      unless hash[:name].is_a?(String) && !hash[:name].empty?
+        raise ArgumentError, "from_h: :name must be a non-empty String"
+      end
+      unless hash[:base].is_a?(Integer)
+        raise ArgumentError, "from_h: :base must be an Integer"
+      end
+      unless hash[:span].is_a?(Integer) && hash[:span] != 0
+        raise ArgumentError, "from_h: :span must be a non-zero Integer"
+      end
+      unless hash[:weeks].is_a?(Array)
+        raise ArgumentError, "from_h: :weeks must be an Array"
+      end
 
       name = hash[:name]
-      if workpatterns.key?(name)
-        if overwrite
-          workpatterns.delete(name)
-        else
-          raise NameError, "Workpattern '#{name}' already exists and can't be created again"
-        end
+      if workpatterns.key?(name) && !overwrite
+        raise NameError, "Workpattern '#{name}' already exists and can't be created again"
       end
 
       wp = allocate
@@ -204,9 +213,11 @@ module Workpattern
 
       weeks = SortedSet.new
       hash[:weeks].each { |wh| weeks << Week.from_h(wh) }
+      raise ArgumentError, "from_h: :weeks must not be empty" if weeks.empty?
       wp.instance_variable_set(:@weeks, weeks)
       wp.instance_variable_set(:@week_pattern, WeekPattern.new(wp))
 
+      workpatterns.delete(name) if overwrite
       workpatterns[name] = wp
       wp
     end

--- a/test/test_day.rb
+++ b/test/test_day.rb
@@ -269,8 +269,8 @@ class TestDay < WorkpatternTest #:nodoc:
   def test_to_h_returns_pattern_and_hours_per_day
     day = working_day
     h = day.to_h
-    assert_equal :pattern, h.keys[0]
-    assert_equal :hours_per_day, h.keys[1]
+    assert h.key?(:pattern)
+    assert h.key?(:hours_per_day)
     assert_instance_of String, h[:pattern]
     assert_equal 24, h[:hours_per_day]
   end
@@ -302,6 +302,16 @@ class TestDay < WorkpatternTest #:nodoc:
     assert_equal day.first_working_minute.min, restored.first_working_minute.min
     assert_equal day.last_working_minute.hour, restored.last_working_minute.hour
     assert_equal day.last_working_minute.min, restored.last_working_minute.min
+    assert_equal day.working_minutes, restored.working_minutes
+  end
+
+  def test_from_h_round_trips_partial_day_working_minutes
+    day = working_day
+    day.set_resting(set_time(0, 0), set_time(8, 59))
+    day.set_resting(set_time(17, 0), set_time(23, 59))
+    restored = Workpattern::Day.from_h(day.to_h)
+    assert_equal day.working_minutes, restored.working_minutes
+    assert_equal 480, restored.working_minutes
   end
 
   def test_pattern_setter_updates_cache

--- a/test/test_day.rb
+++ b/test/test_day.rb
@@ -265,6 +265,54 @@ class TestDay < WorkpatternTest #:nodoc:
      assert_equal Workpattern::SAME_DAY, r_offset, "should be SAME_DAY"
 
    end
+
+  def test_to_h_returns_pattern_and_hours_per_day
+    day = working_day
+    h = day.to_h
+    assert_equal :pattern, h.keys[0]
+    assert_equal :hours_per_day, h.keys[1]
+    assert_instance_of String, h[:pattern]
+    assert_equal 24, h[:hours_per_day]
+  end
+
+  def test_to_h_pattern_is_hex_string
+    day = working_day
+    assert_match(/\A[0-9a-f]+\z/, day.to_h[:pattern])
+  end
+
+  def test_from_h_round_trips_working_day
+    day = working_day
+    restored = Workpattern::Day.from_h(day.to_h)
+    assert_equal day.pattern, restored.pattern
+    assert_equal 1440, restored.working_minutes
+  end
+
+  def test_from_h_round_trips_resting_day
+    day = resting_day
+    restored = Workpattern::Day.from_h(day.to_h)
+    assert_equal day.pattern, restored.pattern
+    assert_equal 0, restored.working_minutes
+  end
+
+  def test_from_h_restores_cache_first_and_last_minute
+    day = working_day
+    day.set_resting(set_time(0, 0), set_time(8, 59))
+    restored = Workpattern::Day.from_h(day.to_h)
+    assert_equal day.first_working_minute.hour, restored.first_working_minute.hour
+    assert_equal day.first_working_minute.min, restored.first_working_minute.min
+    assert_equal day.last_working_minute.hour, restored.last_working_minute.hour
+    assert_equal day.last_working_minute.min, restored.last_working_minute.min
+  end
+
+  def test_pattern_setter_updates_cache
+    day = working_day
+    assert_equal 1440, day.working_minutes
+    day.pattern = resting_day.pattern
+    assert_nil day.first_working_minute
+    assert_nil day.last_working_minute
+    assert_equal 0, day.working_minutes
+  end
+
   private
 
   def working_day

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,6 @@ if RUBY_VERSION < "2"
     class WorkpatternTest < MiniTest::Unit::TestCase
     end
 else
-    class WorkpatternTest < MiniTest::Test
+    class WorkpatternTest < Minitest::Test
     end
 end

--- a/test/test_week.rb
+++ b/test/test_week.rb
@@ -518,6 +518,58 @@ class TestWeek < WorkpatternTest #:nodoc:
     assert_equal Time.gm(2013, 10, 15, 10, 0), start
   end
 
+  def test_to_h_structure
+    start  = Time.gm(2020, 1, 1)
+    finish = Time.gm(2020, 12, 31)
+    w = week(start, finish, 1)
+    h = w.to_h
+    assert_equal 2020, h[:start][:year]
+    assert_equal 1,    h[:start][:month]
+    assert_equal 1,    h[:start][:day]
+    assert_equal 2020, h[:finish][:year]
+    assert_equal 12,   h[:finish][:month]
+    assert_equal 31,   h[:finish][:day]
+    assert_equal 7,    h[:days].length
+    h[:days].each do |dh|
+      assert dh.key?(:pattern)
+      assert dh.key?(:hours_per_day)
+    end
+  end
+
+  def test_from_h_round_trips_working_week
+    start  = Time.gm(2020, 1, 1)
+    finish = Time.gm(2020, 12, 31)
+    w = week(start, finish, 1)
+    w2 = Workpattern::Week.from_h(w.to_h)
+    (0..6).each do |day|
+      assert_equal w.days[day].pattern, w2.days[day].pattern
+      assert_equal w.days[day].working_minutes, w2.days[day].working_minutes
+    end
+  end
+
+  def test_from_h_round_trips_resting_weekends
+    start  = Time.gm(2020, 1, 1)
+    finish = Time.gm(2020, 12, 31)
+    w = week(start, finish, 1)
+    w.workpattern(:weekend, set_time(0, 0), set_time(23, 59), 0)
+    w2 = Workpattern::Week.from_h(w.to_h)
+    assert_equal 0, w2.days[0].working_minutes  # Sunday
+    assert_equal 0, w2.days[6].working_minutes  # Saturday
+    assert_equal w.days[1].working_minutes, w2.days[1].working_minutes  # Monday
+  end
+
+  def test_from_h_preserves_working_query
+    start  = Time.gm(2020, 6, 1)
+    finish = Time.gm(2020, 6, 30)
+    w = week(start, finish, 1)
+    w.workpattern(:all, set_time(0, 0), set_time(8, 59), 0)
+    w2 = Workpattern::Week.from_h(w.to_h)
+    probe = Time.gm(2020, 6, 1, 9, 0)  # Monday 09:00 — working
+    assert_equal w.working?(probe), w2.working?(probe)
+    probe2 = Time.gm(2020, 6, 1, 8, 0)  # Monday 08:00 — resting
+    assert_equal w.working?(probe2), w2.working?(probe2)
+  end
+
   private
 
   def week(start, finish, type)
@@ -526,5 +578,5 @@ class TestWeek < WorkpatternTest #:nodoc:
 
   def set_time(hour,min)
     Time.gm(1963,6,10,hour,min)
-  end  
+  end
 end

--- a/test/test_workpattern_serialisation.rb
+++ b/test/test_workpattern_serialisation.rb
@@ -1,0 +1,160 @@
+require File.dirname(__FILE__) + '/test_helper.rb'
+
+class TestWorkpatternSerialisation < WorkpatternTest
+  def setup
+    Workpattern.clear
+  end
+
+  # 1. to_h basic structure
+  def test_to_h_includes_version_1
+    wp = Workpattern.new('basic', 2020, 1)
+    assert_equal 1, wp.to_h[:version]
+  end
+
+  def test_to_h_includes_name_base_span
+    wp = Workpattern.new('myname', 2021, 3)
+    h = wp.to_h
+    assert_equal 'myname', h[:name]
+    assert_equal 2021,     h[:base]
+    assert_equal 3,        h[:span]
+  end
+
+  def test_to_h_includes_weeks_array_with_start_finish_days
+    wp = Workpattern.new('struct', 2020, 1)
+    h = wp.to_h
+    assert_instance_of Array, h[:weeks]
+    refute_empty h[:weeks]
+    wh = h[:weeks].first
+    assert wh.key?(:start)
+    assert wh.key?(:finish)
+    assert wh.key?(:days)
+    assert_equal 7, wh[:days].length
+  end
+
+  # 2. to_h is idempotent
+  def test_to_h_is_idempotent
+    wp = Workpattern.new('idem', 2020, 2)
+    wp.resting(days: :weekend)
+    assert_equal wp.to_h, wp.to_h
+  end
+
+  # 3. from_h missing :version raises ArgumentError
+  def test_from_h_missing_version_raises_argument_error
+    err = assert_raises(ArgumentError) { Workpattern.from_h({}) }
+    assert_match(/version/, err.message)
+  end
+
+  # 4. from_h unsupported version raises ArgumentError with version in message
+  def test_from_h_unsupported_version_raises_argument_error
+    err = assert_raises(ArgumentError) do
+      Workpattern.from_h({ version: 99, name: 'x', base: 2020, span: 1, weeks: [] })
+    end
+    assert_match(/99/, err.message)
+    assert_match(/unsupported/, err.message)
+  end
+
+  # 5. from_h name conflict raises NameError (AE1)
+  def test_from_h_name_conflict_raises_name_error
+    wp = Workpattern.new('conflict', 2020, 1)
+    err = assert_raises(NameError) { Workpattern.from_h(wp.to_h) }
+    assert_match(/conflict/, err.message)
+  end
+
+  # 6. from_h name conflict with overwrite: true succeeds (AE2)
+  def test_from_h_overwrite_replaces_existing
+    wp = Workpattern.new('overwrite_me', 2020, 1)
+    wp.resting(days: :weekend)
+    h = wp.to_h
+    wp2 = Workpattern.from_h(h, overwrite: true)
+    assert_instance_of Workpattern::Workpattern, wp2
+    assert_equal 'overwrite_me', wp2.name
+  end
+
+  # 7. Round-trip: all-working workpattern
+  def test_round_trip_all_working
+    wp = Workpattern.new('all_working', 2020, 2)
+    h = wp.to_h
+    Workpattern.delete('all_working')
+    wp2 = Workpattern.from_h(h)
+    t1 = Time.gm(2020, 6, 1, 9, 0)
+    t2 = Time.gm(2020, 6, 1, 17, 0)
+    assert_equal wp.diff(t1, t2), wp2.diff(t1, t2)
+    assert_equal wp.working?(t1), wp2.working?(t1)
+    assert_equal wp.calc(t1, 480), wp2.calc(t1, 480)
+  end
+
+  # 8. Round-trip: resting weekends
+  def test_round_trip_resting_weekends
+    wp = Workpattern.new('weekends_off', 2020, 2)
+    wp.resting(days: :weekend)
+    h = wp.to_h
+    Workpattern.delete('weekends_off')
+    wp2 = Workpattern.from_h(h)
+    saturday = Time.gm(2020, 6, 6, 12, 0)  # a Saturday
+    monday   = Time.gm(2020, 6, 8, 12, 0)  # a Monday
+    assert_equal false, wp2.working?(saturday)
+    assert_equal true,  wp2.working?(monday)
+    assert_equal wp.diff(saturday, monday), wp2.diff(saturday, monday)
+  end
+
+  # 9. Round-trip: business hours 09:00-17:00 weekdays (AE3)
+  def test_round_trip_business_hours
+    wp = Workpattern.new('biz_hours', 2020, 3)
+    wp.resting(days: :weekend)
+    wp.resting(days: :weekday,
+               from_time: Workpattern.clock(0, 0),
+               to_time:   Workpattern.clock(8, 59))
+    wp.resting(days: :weekday,
+               from_time: Workpattern.clock(17, 0),
+               to_time:   Workpattern.clock(23, 59))
+    h = wp.to_h
+    Workpattern.delete('biz_hours')
+    wp2 = Workpattern.from_h(h)
+
+    # weekday morning — resting at 08:00, working at 09:00
+    monday_morning = Time.gm(2020, 6, 8, 8, 0)
+    monday_nine    = Time.gm(2020, 6, 8, 9, 0)
+    assert_equal wp.working?(monday_morning), wp2.working?(monday_morning)
+    assert_equal wp.working?(monday_nine),    wp2.working?(monday_nine)
+
+    # diff across a full business day
+    t1 = Time.gm(2020, 6, 8, 9, 0)
+    t2 = Time.gm(2020, 6, 8, 17, 0)
+    assert_equal wp.diff(t1, t2), wp2.diff(t1, t2)
+
+    # calc: add 480 minutes from monday 09:00
+    assert_equal wp.calc(t1, 480), wp2.calc(t1, 480)
+
+    # diff spanning a weekend
+    t3 = Time.gm(2020, 6, 5, 9, 0)   # Friday
+    t4 = Time.gm(2020, 6, 8, 17, 0)  # Monday
+    assert_equal wp.diff(t3, t4), wp2.diff(t3, t4)
+  end
+
+  # 10. from_h registers the workpattern — Workpattern.get returns it
+  def test_from_h_registers_in_registry
+    wp = Workpattern.new('registered', 2020, 1)
+    h = wp.to_h
+    Workpattern.delete('registered')
+    Workpattern.from_h(h)
+    assert_instance_of Workpattern::Workpattern, Workpattern.get('registered')
+  end
+
+  # 11. from_h overwrite: true — registry has exactly one entry for the name
+  def test_from_h_overwrite_no_duplicate_in_registry
+    wp = Workpattern.new('unique', 2020, 1)
+    h = wp.to_h
+    Workpattern.from_h(h, overwrite: true)
+    names = Workpattern.workpatterns.keys.select { |k| k == 'unique' }
+    assert_equal 1, names.length
+  end
+
+  # 12. from_h with string-keyed hash (JSON default) raises ArgumentError with symbolize_names hint
+  def test_from_h_string_keys_gives_actionable_error
+    wp = Workpattern.new('strkeys', 2020, 1)
+    # Simulate JSON.parse without symbolize_names: true
+    string_keyed = { 'version' => 1, 'name' => 'strkeys', 'base' => 2020, 'span' => 1, 'weeks' => [] }
+    err = assert_raises(ArgumentError) { Workpattern.from_h(string_keyed) }
+    assert_match(/symbolize_names/, err.message)
+  end
+end

--- a/test/test_workpattern_serialisation.rb
+++ b/test/test_workpattern_serialisation.rb
@@ -68,6 +68,8 @@ class TestWorkpatternSerialisation < WorkpatternTest
     wp2 = Workpattern.from_h(h, overwrite: true)
     assert_instance_of Workpattern::Workpattern, wp2
     assert_equal 'overwrite_me', wp2.name
+    saturday = Time.gm(2020, 6, 6, 12, 0)
+    assert_equal false, wp2.working?(saturday)
   end
 
   # 7. Round-trip: all-working workpattern
@@ -151,10 +153,33 @@ class TestWorkpatternSerialisation < WorkpatternTest
 
   # 12. from_h with string-keyed hash (JSON default) raises ArgumentError with symbolize_names hint
   def test_from_h_string_keys_gives_actionable_error
-    wp = Workpattern.new('strkeys', 2020, 1)
     # Simulate JSON.parse without symbolize_names: true
     string_keyed = { 'version' => 1, 'name' => 'strkeys', 'base' => 2020, 'span' => 1, 'weeks' => [] }
     err = assert_raises(ArgumentError) { Workpattern.from_h(string_keyed) }
     assert_match(/symbolize_names/, err.message)
+  end
+
+  # 13. overwrite: true with malformed hash leaves original intact
+  def test_from_h_overwrite_malformed_preserves_original
+    wp = Workpattern.new('atomic', 2020, 1)
+    wp.resting(days: :weekend)
+    bad_hash = wp.to_h.merge(weeks: [{ start: {year:2020,month:1,day:1}, finish: {year:2020,month:12,day:31}, days: nil }])
+    assert_raises(NoMethodError) { Workpattern.from_h(bad_hash, overwrite: true) }
+    assert_instance_of Workpattern::Workpattern, Workpattern.get('atomic')
+    saturday = Time.gm(2020, 6, 6, 12, 0)
+    assert_equal false, Workpattern.get('atomic').working?(saturday)
+  end
+
+  # 14. Round-trip: negative span
+  def test_round_trip_negative_span
+    wp = Workpattern.new('neg_span', 2020, -2)
+    h = wp.to_h
+    Workpattern.delete('neg_span')
+    wp2 = Workpattern.from_h(h)
+    assert_equal wp.from, wp2.from
+    assert_equal wp.to,   wp2.to
+    assert_equal wp.span, wp2.span
+    t1 = Time.gm(2019, 6, 1, 9, 0)
+    assert_equal wp.working?(t1), wp2.working?(t1)
   end
 end


### PR DESCRIPTION
## Why
                                                                                                                                                                                           
  Workpattern has had a `persistence_class=` callback since 2012 but it was
  silently broken in every release (a `@@persist`/`@@persistence` typo meant                                                                                                               
  nothing was ever stored). This replaces it with a simple, explicit        
  `to_h`/`from_h` API that actually works.                                                                                                                                                 
                                                                                                                                                                                           
  ## What changed                                                                                                                                                                          
                                                                                                                                                                                           
  - `Workpattern#to_h` serialises a workpattern to a plain Ruby hash. Pattern
    bitmaps are hex-encoded so the result is JSON-safe.                                                                                                                                    
  - `Workpattern.from_h(hash, overwrite: false)` reconstructs a workpattern
    from that hash. Requires symbol keys — if you're round-tripping through                                                                                                                
    JSON use `JSON.parse(json, symbolize_names: true)`.                                                                                                                                    
  - `Workpattern.persistence_class=` and `Workpattern.persistence?` are                                                                                                                    
    **removed**. Both were non-functional; no working integration exists.                                                                                                                  
  - Version bumped to **0.7.0** (breaking change: removed methods).                                                                                                                        
                                                                                                                                                                                           
  ## Approach                                                                                                                                                                              
                                                                                                                                                                                           
  `from_h` uses `allocate` + `instance_variable_set` to reconstruct objects                                                                                                                
  without triggering `initialize`'s duplicate-name guard. Registry mutation                                                                                                                
  happens only after the full object graph is built, so a malformed hash   
  never leaves a name permanently removed.                                                                                                                                                 
                                                                                                                                                                                           
  ## Testing                                                                                                                                                                               
                                                                                                                                                                                           
  ```sh                                                           
  ruby -Ilib -Itest -e 'Dir["test/test_*.rb"].each{|f| require File.expand_path(f)}'                                                                                                       
  # 124 runs, 0 failures                                                            
                                                                                                                                                                                           
  Follow-up (not in this PR)                                                                                                                                                               
   
  - Thread-safety of @@workpatterns under concurrent writes                                                                                                                                
  - Formal version: 1 schema documentation                        
  - Week#hours_per_day is not round-tripped (always restores to 24, which
  is the only value ever used in practice)