### PR TITLE
fix: make the named-workpattern registry thread-safe

### DIFF
--- a/.context/compound-engineering/ce-code-review/20260724-164636-4fe13b83/adversarial.json
+++ b/.context/compound-engineering/ce-code-review/20260724-164636-4fe13b83/adversarial.json
@@ -1,0 +1,53 @@
+{
+  "reviewer": "adversarial",
+  "findings": [
+    {
+      "title": "Recovery cascade: non-NameError exception leaks racing thread past test",
+      "severity": "P2",
+      "file": "test/test_workpattern_registry_concurrency.rb",
+      "line": 26,
+      "why_it_matters": "The per-thread block only rescues NameError, and thread exceptions are re-raised on Thread#join, not captured cooperatively. If any thread in the GC.stress race raises anything other than NameError (e.g. a transient error surfaced by the stress-forced GC checkpoints this test deliberately induces), Array#each(&:join) aborts on the first offending join and never joins the remaining threads. The begin/ensure only guarantees GC.stress is reset (a process-wide VM flag) -- it does not join or wait for the still-running threads. Those threads keep executing Workpattern.new against the shared @@workpatterns registry after the test method has already raised/failed and Minitest has moved on to the next test, corrupting state for whichever test runs next (setup calls Workpattern.clear, but a late-finishing orphan can re-insert an entry afterward).",
+      "autofix_class": "manual",
+      "owner": "human",
+      "requires_verification": false,
+      "pre_existing": false,
+      "suggested_fix": "Rescue StandardError (not just NameError) in the per-thread body so no exception type can escape unhandled, and make the ensure block itself join every thread (e.g. `ensure; threads.each { |t| t.join rescue nil }; GC.stress = false; end`) so no thread can outlive the test method regardless of what it raises.",
+      "confidence": 100,
+      "evidence": [
+        "Reproduced directly: a 3-thread Array.new(3){ Thread.new { ... } } where thread 0 raises ArgumentError (not rescued) and threads 1/2 sleep before finishing.",
+        "threads.each(&:join) raises on thread 0's join, the ensure block runs (prints 'ensure ran') but 'all joined' is never reached.",
+        "Script exits with the uncaught ArgumentError while threads 1/2 are still sleeping in the background -- confirming they are not joined before control leaves the begin/ensure block.",
+        "Applied to the real test: this is exactly the begin/ensure shape at test/test_workpattern_registry_concurrency.rb:26-42, with only `rescue NameError` guarding the thread body (line 34) and `threads.each(&:join)` at line 39."
+      ]
+    },
+    {
+      "title": "Frozen registry view hides that contained Workpattern objects stay mutable",
+      "severity": "P2",
+      "file": "lib/workpattern/workpattern.rb",
+      "line": 26,
+      "why_it_matters": "Workpattern.workpatterns now returns @@workpatterns.dup.freeze, and the new test (test_workpatterns_returns_frozen_view) is described as covering 'a frozen, mutation-safe view'. But .dup.freeze is shallow: it freezes the Hash object, not its values. The Workpattern instances stored in the registry (and returned unchanged by self.get and self.to_a, which were not touched by this fix) remain live, non-frozen, mutable objects. #working/#resting (via WeekPattern#workpattern) mutate the object's own @weeks SortedSet with no locking at all. Two threads that independently call Workpattern.get('shared-name') and then call #resting/#working on the same returned object race on that SortedSet with exactly the same 'mutate a collection concurrently' hazard class this PR just fixed for @@workpatterns itself -- just one level down, on the object's own state, and entirely unaddressed by this Mutex.",
+      "autofix_class": "advisory",
+      "owner": "human",
+      "requires_verification": true,
+      "pre_existing": true,
+      "suggested_fix": "Document explicitly (in the self.workpatterns comment and README) that the Mutex/frozen-dup only protects the registry's Hash structure, not the mutable state of the Workpattern objects it contains; concurrent mutation of a single named Workpattern is still the caller's responsibility to serialize.",
+      "confidence": 75,
+      "evidence": [
+        "self.workpatterns at lib/workpattern/workpattern.rb:26-28 only dup+freezes the Hash; the values (Workpattern instances) are the same objects stored in @@workpatterns, not duped or frozen.",
+        "lib/workpattern/week_pattern.rb#workpattern (called by Workpattern#working/#resting) mutates work_pattern.weeks (the object's @weeks SortedSet) via `weeks << after_wp` and `current_wp.workpattern(...)` with no synchronization.",
+        "find_weekpattern (lib/workpattern/workpattern.rb:294-308) iterates @weeks via `@weeks.find { ... }` with no lock either, so a concurrent #working call and a concurrent #resting call on the same object retrieved from the registry can race a mutation against an iteration.",
+        "test/test_workpattern_serialisation.rb:203-210 only asserts hash-level FrozenError on injection, not that the objects inside are protected -- the 'mutation-safe view' framing in the comment overstates what is actually guaranteed."
+      ]
+    }
+  ],
+  "residual_risks": [
+    "Composite, multi-call application sequences (e.g. check-then-create via Workpattern.get rescue nil followed by Workpattern.new, or get-then-delete) are still not atomic: each individual registry method call is now atomic under @@mutex, but nothing prevents another thread's call from interleaving between two calls made by the same caller.",
+    "self.from_h holds @@mutex for the entire allocate/Week.from_h-parse-all-weeks/SortedSet-build/insert sequence, not just the existence-check-through-insert. A large or slow-to-parse `hash[:weeks]` array extends the critical section and blocks every other Workpattern.new/get/to_a/delete/from_h call process-wide for that duration.",
+    "Individual Workpattern objects returned by get/to_a/workpatterns remain live shared references whose own mutable state (@weeks) is unguarded by any lock; concurrent #working/#resting/#calc calls against the same named Workpattern can still race."
+  ],
+  "testing_gaps": [
+    "No test exercises concurrent #working/#resting calls against the same named Workpattern object retrieved by multiple threads -- the exact hazard class this PR closes at the registry level is left completely untested at the object level.",
+    "The GC.stress race test's per-thread rescue clause only catches NameError; there is no test asserting that all spawned threads are guaranteed to be joined (or the process left in a clean state) if an unexpected exception type occurs mid-race.",
+    "No test directly asserts Mutex non-reentrancy end-to-end (e.g., that from_h or initialize cannot deadlock if a future change makes WeekPattern.new or Week.new call back into a Workpattern class method) -- current safety relies on manual code inspection rather than an automated guard."
+  ]
+}

--- a/.context/compound-engineering/ce-code-review/20260724-164636-4fe13b83/api-contract.json
+++ b/.context/compound-engineering/ce-code-review/20260724-164636-4fe13b83/api-contract.json
@@ -1,0 +1,33 @@
+{
+  "reviewer": "api-contract",
+  "findings": [
+    {
+      "title": "Workpattern.workpatterns now returns frozen dup",
+      "severity": "P3",
+      "file": "lib/workpattern/workpattern.rb",
+      "line": 26,
+      "confidence": 50,
+      "autofix_class": "advisory",
+      "owner": "human",
+      "requires_verification": false,
+      "pre_existing": false,
+      "suggested_fix": "None required within this repo. If Workpattern.workpatterns is a documented/public API consumed by gems or apps outside this repository, mention the mutability change in CHANGELOG/release notes so external maintainers relying on hash identity or in-place mutation of the returned registry are aware.",
+      "evidence": [
+        "lib/workpattern/workpattern.rb:26-30 changes `def self.workpatterns; @@workpatterns; end` to `@@mutex.synchronize { @@workpatterns.dup.freeze }`",
+        "lib/workpattern.rb:92-94 facade delegates directly to Workpattern::Workpattern.workpatterns, propagating the frozen-dup return value unchanged",
+        "grep across test/*.rb and README.md finds only two call sites: test/test_workpattern_serialisation.rb:163 (`Workpattern.workpatterns.keys.select { ... }`, read-only) and the new test at test/test_workpattern_serialisation.rb:203-210, both compatible with a frozen dup",
+        "No occurrences of `.equal?`, `object_id`, or index-assignment (`workpatterns[...] =`) against the .workpatterns return value anywhere in lib/ or test/",
+        "README.md contains no reference to `.workpatterns` at all",
+        "Full test suite (124 runs, 9115 assertions) passes with the change, including the new frozen-view regression test"
+      ]
+    }
+  ],
+  "residual_risks": [
+    "Workpattern.workpatterns' return value changing from a live Hash reference to a frozen duplicate is technically a backward-incompatible type/behavior change (mutable -> immutable, object identity no longer matches internal registry). Within this repository no caller depends on mutability or identity, and the change closes a real thread-safety hole, so risk is low. However, this method is public and re-exported via the lib/workpattern.rb facade with no gem version bump or CHANGELOG entry evident in this diff; any external consumer outside this repo that captured the hash and later wrote to it (e.g. `Workpattern.workpatterns[name] = wp`) would start seeing FrozenError instead of silent mutation. Recommend a minor version bump and changelog note given this is a public gem API, even though it's a safety fix rather than a feature change.",
+    "Values inside the returned Hash (the Workpattern objects themselves) are not frozen, only the Hash structure — a caller can still mutate an individual Workpattern object's internal state via its own instance methods; this was true before and after the change and is unaffected here, but is worth noting as a boundary of what the fix actually protects."
+  ],
+  "testing_gaps": [
+    "No test asserts that Workpattern.workpatterns returns a new object each call (i.e., that repeated calls are not aliased to the same frozen dup) — not required for correctness but would make the 'always call-time dup' contract explicit.",
+    "No test verifies that mutating a Workpattern object retrieved from Workpattern.workpatterns (e.g. calling a mutating instance method) is unaffected by the hash being frozen, i.e. that only the Hash container is frozen and not its values."
+  ]
+}

--- a/.context/compound-engineering/ce-code-review/20260724-164636-4fe13b83/correctness.json
+++ b/.context/compound-engineering/ce-code-review/20260724-164636-4fe13b83/correctness.json
@@ -1,0 +1,14 @@
+{
+  "reviewer": "correctness",
+  "findings": [],
+  "residual_risks": [
+    "Workpattern.initialize now holds @@mutex for the entire object-construction critical section (Time.gm calls, Week.new, WeekPattern.new), not just the check-then-insert window described in the intent. This is not a correctness bug (no deadlock: WeekPattern.new and Week.new do not call back into any @@mutex-guarded class method), but it does mean all concurrent Workpattern.new calls -- even for distinct, non-colliding names -- are now fully serialized rather than only the registry mutation being serialized.",
+    "@@mutex (via Mutex#synchronize) is not reentrant, as the code comment correctly notes. This is safe today because no method that holds the lock calls another @@mutex-guarded method, but it is a latent deadlock trap for future maintainers: any refactor that has initialize, from_h, get, delete, to_a, or clear call each other directly (instead of duplicating @@workpatterns access) would deadlock silently rather than raising immediately.",
+    "Workpattern.workpatterns returns a frozen dup of the hash, but the Workpattern objects it contains are not frozen/duplicated -- external callers can still mutate a live registry entry's internal state (e.g. call .resting on it) without holding @@mutex. This matches the stated intent ('no public visibility-model change') but means the fix only protects the registry container, not the objects inside it."
+  ],
+  "testing_gaps": [
+    "The new concurrency tests only stress Workpattern.new racing against itself (AE1) and a mixed workload of new/get/to_a/delete on distinct names (AE2). Workpattern.from_h's uniqueness race (the same check-then-act pattern, now also mutex-guarded) is not exercised by a GC.stress-style test, so a regression that breaks locking specifically in from_h would not be caught by the new suite.",
+    "No test exercises a same-name collision across different entry points (e.g. Workpattern.new(name) racing Workpattern.from_h({name: ...}) for the same name), which is the scenario most likely to reveal an inconsistency if one of the two code paths were ever changed to use a different lock or none at all.",
+    "The GC.stress-based test is explicitly acknowledged by its own comments to be timing-sensitive; no CI-specific safeguard (e.g. a timeout wrapper) is added, so a slow/loaded CI runner could make this test hang or run long rather than fail fast if the underlying race were reintroduced."
+  ]
+}

--- a/.context/compound-engineering/ce-code-review/20260724-164636-4fe13b83/maintainability.json
+++ b/.context/compound-engineering/ce-code-review/20260724-164636-4fe13b83/maintainability.json
@@ -1,0 +1,48 @@
+{
+  "reviewer": "maintainability",
+  "findings": [],
+  "residual_risks": [
+    {
+      "title": "Workpattern.workpatterns contract change undocumented in CHANGELOG",
+      "severity": "P3",
+      "file": "lib/workpattern/workpattern.rb",
+      "line": 26,
+      "why_it_matters": "Workpattern.workpatterns previously returned the live, mutable @@workpatterns Hash; it now returns a frozen duplicate (self.class's own registry hash is frozen; the top-level Workpattern.workpatterns facade in lib/workpattern.rb just forwards this). Any external caller of this gem that mutated the returned hash directly (e.g. Workpattern.workpatterns[name] = wp, or Workpattern.workpatterns.delete(name)) will now raise FrozenError instead of silently succeeding. This is an intentional and reasonable fix, but it is a public-API behavior change for a gem (CHANGELOG.md's unreleased v0.7.0 section documents to_h/from_h additions but has no entry for this). A maintainer bumping/publishing the release without noting this could surprise downstream consumers.",
+      "autofix_class": "advisory",
+      "owner": "release",
+      "requires_verification": true,
+      "suggested_fix": "Add a CHANGELOG.md entry under v0.7.0 noting that Workpattern.workpatterns now returns a frozen snapshot rather than the live registry hash.",
+      "confidence": 50,
+      "evidence": [
+        "lib/workpattern/workpattern.rb:26-28 def self.workpatterns; @@mutex.synchronize { @@workpatterns.dup.freeze }; end",
+        "CHANGELOG.md v0.7.0 (unreleased) section lists to_h/from_h additions but no entry for the workpatterns() return-value change",
+        "test/test_workpattern_serialisation.rb:203-210 new test_workpatterns_returns_frozen_view confirms the new FrozenError behavior is intentional"
+      ],
+      "pre_existing": false
+    },
+    {
+      "title": "Mutex protects registry only, not per-instance Workpattern mutation",
+      "severity": "P3",
+      "file": "lib/workpattern/workpattern.rb",
+      "line": 145,
+      "why_it_matters": "The new @@mutex only serializes name -> Workpattern registry operations (create/lookup/delete/clear). A Workpattern instance obtained via Workpattern.get(name) can still have #workpattern / #working / #resting called concurrently by multiple threads, which mutate @weeks (a SortedSet) via WeekPattern#workpattern with no locking at all. The PR's framing ('closes a concurrent-mutation hazard') is scoped to the registry structure, but a future maintainer skimming the class comment or CHANGELOG could reasonably assume Workpattern as a whole is now safe for concurrent use, which it is not.",
+      "autofix_class": "advisory",
+      "owner": "human",
+      "requires_verification": false,
+      "suggested_fix": "Add a doc note on the class (or in the CHANGELOG) clarifying that the mutex covers only the class-level registry, not concurrent mutation of a single Workpattern instance's own state.",
+      "confidence": 50,
+      "evidence": [
+        "lib/workpattern/workpattern.rb:145-147 def workpattern(opts = {}); week_pattern.workpattern(opts); end -- no locking",
+        "lib/workpattern/workpattern.rb:20-28 @@mutex only wraps @@workpatterns registry access, not instance mutation paths"
+      ],
+      "pre_existing": true
+    }
+  ],
+  "testing_gaps": [
+    {
+      "title": "No test for concurrent mutation of a single shared Workpattern instance",
+      "file": "test/test_workpattern_registry_concurrency.rb",
+      "why_it_matters": "Both new concurrency tests exercise registry-level operations (new/get/delete/to_a/clear) but none exercise two threads calling #working, #resting, or #workpattern on the same Workpattern instance retrieved via Workpattern.get -- the actual case where @weeks (SortedSet) mutation races would surface. Given the PR is framed around 'closing a concurrent-mutation hazard', a reader could mistake the new tests as covering that broader case."
+    }
+  ]
+}

--- a/.context/compound-engineering/ce-code-review/20260724-164636-4fe13b83/project-standards.json
+++ b/.context/compound-engineering/ce-code-review/20260724-164636-4fe13b83/project-standards.json
@@ -1,0 +1,8 @@
+{
+  "reviewer": "project-standards",
+  "findings": [],
+  "residual_risks": [
+    "No CLAUDE.md/AGENTS.md standards files exist in this repository, so this review persona has no codified rules to check the Mutex/registry change against."
+  ],
+  "testing_gaps": []
+}

--- a/.context/compound-engineering/ce-code-review/20260724-164636-4fe13b83/reliability.json
+++ b/.context/compound-engineering/ce-code-review/20260724-164636-4fe13b83/reliability.json
@@ -1,0 +1,32 @@
+{
+  "reviewer": "reliability",
+  "findings": [
+    {
+      "title": "Mutex held across full object construction, not just check-then-act",
+      "severity": "P2",
+      "file": "lib/workpattern/workpattern.rb",
+      "line": 66,
+      "why_it_matters": "The @@mutex.synchronize block in #initialize (and similarly in .from_h, lines 193-217) wraps the entire object build -- Time.gm calls, SortedSet/Week construction, and WeekPattern.new -- not just the name-uniqueness check plus registry insert. This serializes every Workpattern.new/from_h call process-wide even when the names don't collide, turning what could be independent, parallel creations into a fully serialized critical section. Under a workload that creates many distinct workpatterns concurrently, this is a new global bottleneck introduced by this diff (previously there was no lock at all).",
+      "autofix_class": "manual",
+      "owner": "human",
+      "requires_verification": true,
+      "pre_existing": false,
+      "suggested_fix": "Build the Weeks/WeekPattern object outside the lock, then acquire @@mutex only to re-check `@@workpatterns.key?(name)` and perform the insert (mirroring the from_h overwrite pattern), shrinking the critical section to the minimal check+insert.",
+      "confidence": 75,
+      "evidence": [
+        "lib/workpattern/workpattern.rb:66-81 wraps Time.gm/SortedSet/Week.new/WeekPattern.new inside @@mutex.synchronize",
+        "lib/workpattern/workpattern.rb:193-217 wraps the equivalent from_h construction inside the same mutex"
+      ]
+    }
+  ],
+  "residual_risks": [
+    "Only the class-level registry (@@workpatterns) is now guarded by @@mutex; individual Workpattern instances returned by .get/.workpatterns/.to_a are live, mutable, unsynchronized objects. Concurrent calls to instance methods that mutate state (e.g. #workpattern/#resting/#working touching @weeks) on the same Workpattern from multiple threads remain unprotected and can still corrupt the SortedSet -- this diff does not and does not claim to address that layer.",
+    "@@mutex and @@workpatterns are class variables (@@), which in Ruby are shared with any subclass of Workpattern; this is consistent with the pre-existing @@workpatterns design but means the lock scope is process-wide across the class hierarchy, not just this class.",
+    "Ruby's Mutex#synchronize has no timeout parameter, so any future code path added inside a locked block that blocks or loops indefinitely would stall all registry access process-wide; today's critical sections are pure in-memory computation with no I/O, so this is not currently exercised."
+  ],
+  "testing_gaps": [
+    "No test exercises concurrent mutation of a single Workpattern instance's internal state (e.g. concurrent #working/#resting calls) to establish whether that layer is safe or not now that the registry itself is protected.",
+    "No test verifies registry consistency when Week.from_h raises mid-construction inside .from_h under concurrent access (confirming the partially-built `wp` never reaches @@workpatterns) -- current tests only cover the from_h happy path and the .new uniqueness race.",
+    "No test covers Workpattern.clear racing with in-flight .new/.from_h calls."
+  ]
+}

--- a/.context/compound-engineering/ce-code-review/20260724-164636-4fe13b83/testing.json
+++ b/.context/compound-engineering/ce-code-review/20260724-164636-4fe13b83/testing.json
@@ -1,0 +1,33 @@
+{
+  "reviewer": "testing",
+  "findings": [
+    {
+      "title": "from_h's uniqueness race is never exercised concurrently",
+      "severity": "P2",
+      "file": "lib/workpattern/workpattern.rb",
+      "line": 194,
+      "why_it_matters": "The stated intent is that the Mutex closes a check-then-act uniqueness race in *both* initialize and from_h. The new concurrency test file empirically reproduces and proves the fix only for Workpattern.new (verified: reverting the mutex reliably makes test_concurrent_creation_with_same_name_exactly_one_succeeds fail 3/3 runs, and the fixed code passes 5/5 runs). No test in test_workpattern_registry_concurrency.rb calls Workpattern.from_h at all -- the identical existence-check-then-insert pattern at line 194 (and the overwrite variant at lines 214-215) is exercised only by single-threaded tests in test_workpattern_serialisation.rb. If a future refactor of from_h (e.g. someone hoists the existence check back out of the synchronize block while 'simplifying' it, mirroring the exact bug this diff fixes for initialize) reintroduces the race, no test would catch it, because none exercises from_h under actual thread contention.",
+      "autofix_class": "manual",
+      "owner": "human",
+      "requires_verification": true,
+      "suggested_fix": "Add a GC.stress-based concurrency test analogous to test_concurrent_creation_with_same_name_exactly_one_succeeds but driving Workpattern.from_h(same_hash) from multiple threads (and ideally a variant with overwrite: true) to empirically prove the from_h check-then-act path is also race-free.",
+      "confidence": 75,
+      "evidence": [
+        "grep for from_h in test/test_workpattern_registry_concurrency.rb returns no matches -- from_h is never invoked by any concurrency test.",
+        "lib/workpattern/workpattern.rb:194 -- raise NameError ... if @@workpatterns.key?(name) && !overwrite -- structurally identical check-then-act pattern to the one fixed (and empirically regression-tested) in initialize at line 67.",
+        "Manually reverting the Mutex/lib change and re-running test/test_workpattern_registry_concurrency.rb reproduces the claimed pre-fix failure (3/3 runs: 'expected exactly one thread to win the race. Actual: 3') only for the initialize path, confirming that path -- and only that path -- is empirically regression-tested."
+      ],
+      "pre_existing": false
+    }
+  ],
+  "residual_risks": [
+    "test_concurrent_mixed_operations_do_not_corrupt_registry (test/test_workpattern_registry_concurrency.rb:52) is documented in its own comments as unable to reliably force the 'concurrent-mutation hazard on reads' the Mutex is meant to close for self.get/self.to_a/self.delete; it runs at natural thread-scheduling speed and only asserts that no exception escapes and that final registry entries are well-formed. This means half of the stated intent (protecting reads/get/to_a/delete against concurrent Hash mutation) is smoke-tested but not empirically proven the way the uniqueness race is -- a regression in that path could pass CI most of the time.",
+    "GC.stress-based tests (test/test_workpattern_registry_concurrency.rb) rely on CRuby/MRI-specific GC scheduling to force interleaving; the gemspec only requires Ruby >= 3.1 with no engine restriction, so on alternative Ruby implementations (JRuby, TruffleRuby) GC.stress semantics may differ or be unsupported, which could make this test silently weaker (or need skip guards) if the project is ever run there. Also adds roughly 7-9 seconds to every test run.",
+    "Workpattern.workpatterns now returns @@workpatterns.dup.freeze -- only the Hash is frozen; the Workpattern objects stored as values remain fully mutable, so external callers can still mutate a workpattern's state through the returned collection. This matches the stated 'no public visibility-model change' intent but is worth keeping in mind if a future intent claims full immutability of the accessor's output."
+  ],
+  "testing_gaps": [
+    "No concurrent (multi-thread/GC.stress) test exercises Workpattern.from_h's existence-check-then-insert critical section (lib/workpattern/workpattern.rb:194) or its overwrite branch (lines 214-215); only Workpattern.new's equivalent race is empirically regression-tested.",
+    "test_concurrent_mixed_operations_do_not_corrupt_registry cannot reliably reproduce the read/mutation hazard on self.get/self.to_a/self.delete that motivated locking those methods, per its own code comments -- it is a best-effort smoke test, not a proof of the fix for that half of the change.",
+    "No test exercises Workpattern.clear running concurrently with Workpattern.new/from_h (e.g. a clear interleaved with in-flight creations), though this is lower risk than the uniqueness/read hazards already covered."
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Removed `Workpattern.persistence_class=` and `Workpattern.persistence?` — both were silently non-functional in all prior releases due to a `@@persist`/`@@persistence` naming bug; no working integration exists.
 * Fixed `DEFAULT_NAME` undefined constant in `Workpattern::Workpattern.initialize` (pre-existing; only triggered when calling the inner class constructor directly with no arguments).
 * Fixed `Array.new(LAST_DAY_OF_WEEK)` → `Array.new(LAST_DAY_OF_WEEK + 1)` in `Week.initialize` for consistency (pre-existing; Ruby auto-extends arrays so no runtime difference).
+* Fixed thread safety of the named-workpattern registry: `Workpattern.new`, `.get`, `.delete`, `.clear`, `.to_a`, and `.from_h` are now guarded by a `Mutex`, closing a check-then-act race on duplicate-name creation and a concurrent-mutation hazard on reads. **Behavior change:** `Workpattern.workpatterns` now returns a frozen duplicate of the registry instead of the live internal hash — mutating the returned object now raises `FrozenError` instead of silently corrupting the registry.
 
 ## Workpattern v0.6.0 ( 25 Feb, 2021) ##
 

--- a/docs/brainstorms/2026-07-24-thread-safe-registry-requirements.md
+++ b/docs/brainstorms/2026-07-24-thread-safe-registry-requirements.md
@@ -1,0 +1,101 @@
+---
+date: 2026-07-24
+topic: thread-safe-registry
+---
+
+# Thread-Safe Named Registry
+
+## Problem Frame
+
+`Workpattern::Workpattern` stores all named workpatterns in a bare class variable, `@@workpatterns = {}` (`lib/workpattern/workpattern.rb:20`), with no synchronisation anywhere in the codebase. `Workpattern.new`, `.get`, `.delete`, `.clear`, `.to_a`, and `.from_h` all read or mutate this hash without a lock.
+
+Under concurrent access — a Rails app serving concurrent requests, a Sidekiq worker pool, or any multi-threaded deployment — this produces two classes of failure:
+
+- **Check-then-act races.** `initialize` raises `NameError` if a name is already registered, then inserts. Two threads creating the same name concurrently can both pass the check and both insert, silently violating the uniqueness guarantee the API promises. The same pattern exists in `from_h`'s overwrite handling.
+- **Concurrent-mutation hazards on the shared hash.** Reading (`to_a`, `get`) while another thread writes (`new`, `delete`, `clear`) can raise `RuntimeError` on Hash iteration, or produce inconsistent reads, depending on interleaving and Ruby engine (this is a genuine parallelism concern on JRuby/TruffleRuby, not just a GIL-interleaving concern on MRI, and the CHANGELOG shows this gem has tested against JRuby historically).
+
+**Verified in code:** `@@workpatterns` (`lib/workpattern/workpattern.rb:20`) is read/written by `initialize` (:62, :74), `self.clear` (:91), `self.to_a` (:98), `self.get` (:106-109), `self.delete` (:118), and `self.from_h` (:190, :210-211) — none behind a lock.
+
+**Note on the originating ideation doc:** The ideation entry that raised this (`docs/ideation/2026-04-26-open-ideation.md`, idea #2) also names `@@persist` and `@@tz` as bare, unsynchronised class variables. Both have since been removed (`@@persist` as part of the persistence-callback removal; `@@tz` in a separate cleanup commit) — verified absent from `lib/` and `test/`. `@@workpatterns` is the only remaining bare class variable this brainstorm addresses.
+
+---
+
+## Requirements
+
+**Concurrency model**
+
+- R1. The single shared registry (`@@workpatterns`) remains as-is in terms of *visibility* — a workpattern created on one thread must still be visible to `.get`/`.to_a` calls from any other thread. This brainstorm does **not** adopt thread-local storage; it makes the existing shared-registry model safe under concurrent access, matching the "safety without visibility change" direction chosen over the ideation doc's thread-local proposal.
+- R2. All registry mutation (`new`, `delete`, `clear`, `from_h`) must be mutually exclusive with all other registry mutation and with registry reads (`get`, `to_a`) — no interleaving of a read with an in-progress write, and no interleaving of two writes.
+- R3. The uniqueness guarantee — "a name already registered raises `NameError` on creation (or on `from_h` without `overwrite: true`)" — must hold under concurrent creation attempts for the same name. Exactly one of two concurrent `Workpattern.new("x")` calls for the same name succeeds; the other raises `NameError`, and the registry ends up with exactly one entry for that name.
+
+**Closing the raw-hash leak**
+
+- R4. `Workpattern.workpatterns` (and the module-level facade `Workpattern.workpatterns` in `lib/workpattern.rb`) must stop returning the live internal hash by reference. It returns a non-mutable view (e.g. a frozen duplicate) so that external callers cannot bypass the synchronised mutation methods by mutating the returned object directly.
+- R5. The changed return value of `.workpatterns` must not break its existing read-only usage (`test/test_workpattern_serialisation.rb:163` calls `.keys.select` on the result) — read-only operations on the returned object continue to work unchanged.
+
+**Testing**
+
+- R6. In addition to normal single-threaded unit tests of the synchronised methods, add a concurrency stress test: multiple threads calling `Workpattern.new`/`.get`/`.delete`/`.clear` concurrently against shared and colliding names, asserting no exceptions escape, no entries are lost or duplicated, and R3's uniqueness guarantee holds under contention.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R3.** Given no workpattern named `"contested"` exists, when 10 threads simultaneously call `Workpattern.new("contested")`, then exactly one thread returns successfully, the other 9 raise `NameError`, and `Workpattern.get("contested")` returns a single valid Workpattern afterward.
+- AE2. **Covers R2, R6.** Given a mix of threads concurrently calling `.new` (distinct names), `.get`, `.to_a`, and `.delete`, when run under a stress test with a high iteration count, then no thread raises an unexpected `RuntimeError` (e.g. "can't add a new key into hash during iteration") and the final registry state is internally consistent (every name present maps to a real Workpattern, no orphaned entries).
+- AE3. **Covers R4, R5.** Given `Workpattern.new("readonly-check")`, when `h = Workpattern.workpatterns` and the caller attempts `h["injected"] = something`, then a `FrozenError` (or equivalent) is raised and the real registry is unaffected; `h.keys.select { |k| k == "readonly-check" }` still returns `["readonly-check"]`.
+
+---
+
+## Success Criteria
+
+- A multi-threaded caller (Rails with concurrent requests, Sidekiq worker pool, JRuby with real parallelism) can create, look up, and delete named workpatterns without risking silent duplicate-name corruption or hash-iteration exceptions.
+- No visibility behavior changes for any existing single-threaded or thread-per-request caller — everything that works today continues to work identically.
+- The raw-hash escape hatch (`Workpattern.workpatterns`) can no longer be used to bypass synchronisation.
+- Planning can implement this without inventing additional concurrency behavior, lock granularity choices, or API surface that belongs in this document.
+
+---
+
+## Scope Boundaries
+
+- No thread-local storage and no "shared base namespace" opt-in — the ideation doc's proposed model was explicitly declined in favor of keeping today's single shared, globally-visible registry.
+- No changes to `Day`, `Week`, or `WeekPattern` internals — this is scoped to the `Workpattern` class-level registry only.
+- No Ractor support and no lock-free/atomics-based redesign — a standard mutual-exclusion primitive around the registry is sufficient for this gem's scale and access pattern (registry operations are infrequent relative to `calc`/`diff`, which never touch `@@workpatterns`).
+- No change to the calculation hot path (`calc`, `diff`, `working?`, `find_weekpattern`) — none of these read `@@workpatterns`; they operate entirely on the instance's own `@weeks`.
+- No configurable locking strategy or pluggable backend — out of scope per the rejected "Pluggable Registry Backends" idea in the ideation doc's rejection summary.
+
+---
+
+## Key Decisions
+
+- **Safety without visibility change, not thread-local-by-default:** The ideation doc's thread-local proposal would silently change which threads can see a given workpattern — a real behavioral/API change disguised as a low-risk internal fix. The chosen direction (synchronise the existing shared registry) fixes the actual defect (unsynchronised concurrent access) with zero behavior change for any current caller.
+- **Close the raw-hash leak in the same pass:** `Workpattern.workpatterns` already returns the live hash by reference (used internally and by one test). Synchronising `new`/`get`/`delete`/`clear`/`from_h` alone would leave this as an unguarded bypass — anyone holding the returned hash could mutate the registry directly. Returning a frozen duplicate closes this without changing any read-only call site.
+- **Stress test required, not optional:** Concurrency defects don't reliably reproduce under normal unit tests (execution order is usually deterministic on one thread). A dedicated multi-thread stress test is the only practical way to demonstrate the race is actually closed rather than merely code-reviewed.
+
+---
+
+## Dependencies / Assumptions
+
+- Registry operations (`new`, `get`, `delete`, `clear`, `from_h`, `to_a`) are infrequent relative to calculation calls (`calc`, `diff`, `working?`) — verified by reading `find_weekpattern` and the calc/diff bodies, which reference only instance-level `@weeks`, `@from`, `@to`, never `@@workpatterns`. This means a straightforward mutual-exclusion primitive introduces no hot-path overhead.
+- `@@persist` and `@@tz` (also named in the ideation doc's warrant) are already removed from the codebase — verified via `grep` across `lib/` and `test/`. Only `@@workpatterns` remains as a bare, unsynchronised class variable.
+- The gem's `required_ruby_version` is `>= 3.1` (per `workpattern.gemspec`) and the CHANGELOG records historical JRuby testing — both support using a standard `Mutex`/`Thread::Mutex` without additional dependencies.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+*(none)*
+
+### Deferred to Planning
+
+- [Affects R2][Technical] Lock granularity: a single global `Mutex` guarding all registry operations, versus finer-grained locking (e.g. separate read/write locks). Given registry operations are infrequent (see Dependencies), planning should default to the simplest option (one global lock) unless a concrete reason emerges to do otherwise.
+- [Affects R2][Technical] Where exactly to draw the critical section in `initialize` and `from_h` — these methods do more than touch the registry (e.g. building `Week`/`WeekPattern` objects). Planning decides how much of each method's body needs to be inside the lock versus only the registry check-and-insert step.
+- [Affects R4][Technical] Exact mechanism for the non-mutable view: frozen shallow `dup`, `Hash#freeze` on a copy, or another read-only wrapper. Planning picks the simplest option that satisfies R5.
+
+---
+
+## Next Steps
+
+→ `/ce-plan` for structured implementation planning

--- a/docs/plans/2026-07-24-001-fix-thread-safe-registry-plan.md
+++ b/docs/plans/2026-07-24-001-fix-thread-safe-registry-plan.md
@@ -1,0 +1,223 @@
+---
+title: "Thread-Safe Named Registry"
+type: fix
+status: completed
+date: 2026-07-24
+origin: docs/brainstorms/2026-07-24-thread-safe-registry-requirements.md
+---
+
+# Thread-Safe Named Registry
+
+## Overview
+
+`Workpattern::Workpattern` keeps every named workpattern in a bare class variable, `@@workpatterns = {}` (`lib/workpattern/workpattern.rb:20`), with no synchronisation. Six class methods read or mutate it (`initialize`, `self.clear`, `self.to_a`, `self.get`, `self.delete`, `self.from_h`) and one method (`self.workpatterns`) leaks the live hash by reference. This plan adds a single `Mutex` guarding all registry access, fixes an incidental ordering bug in `initialize` uncovered while designing the critical section, and changes `self.workpatterns` to return a frozen duplicate instead of the live hash. No public visibility semantics change — a workpattern created on one thread remains visible to every other thread, matching today's behavior.
+
+---
+
+## Problem Frame
+
+Concurrent callers (Rails serving concurrent requests, a Sidekiq worker pool, or JRuby with real thread parallelism — this gem has historically been tested under JRuby, per `.travis.yml:9-10`) can race on `@@workpatterns` in two ways:
+
+- **Check-then-act races**: `initialize` (`workpattern.rb:62`) and `from_h` (`workpattern.rb:190`) each check `workpatterns.key?(name)` then insert afterward, with no atomicity between the two steps. Two threads racing to create the same name can both pass the check.
+- **Concurrent-mutation hazards**: reading (`to_a`, `get`) while another thread writes (`new`, `delete`, `clear`) can raise `RuntimeError` on Hash iteration or produce inconsistent reads.
+
+Separately, `self.workpatterns` (`workpattern.rb:22-24`, facade re-exported at `lib/workpattern.rb:92-94`) returns `@@workpatterns` itself, not a copy. Any caller holding that reference can mutate the registry directly, which would defeat any locking added around the class's own methods.
+
+(See origin: `docs/brainstorms/2026-07-24-thread-safe-registry-requirements.md` for the full problem frame, including why thread-local storage — the ideation doc's original proposal — was explicitly rejected in favor of keeping the existing shared-registry visibility model.)
+
+---
+
+## Requirements Trace
+
+- R1. Registry stays a single shared structure visible to all threads — no thread-local storage, no opt-in shared namespace.
+- R2. All registry mutation (`new`, `delete`, `clear`, `from_h`) is mutually exclusive with all other registry mutation and with registry reads (`get`, `to_a`).
+- R3. The uniqueness guarantee holds under concurrent creation: exactly one of two concurrent `Workpattern.new("x")` calls for the same name succeeds; the registry ends with exactly one entry for that name.
+- R4. `Workpattern.workpatterns` stops returning the live internal hash; it returns a non-mutable view.
+- R5. The changed return value of `.workpatterns` does not break its existing read-only usage (`test/test_workpattern_serialisation.rb:163`).
+- R6. A concurrency stress test demonstrates R2/R3 hold under real multi-threaded contention, not just single-threaded unit tests.
+
+---
+
+## Scope Boundaries
+
+- No thread-local storage, no opt-in "shared base namespace" — explicitly rejected in the origin brainstorm.
+- No changes to `Day`, `Week`, or `WeekPattern` — scoped to the `Workpattern` class-level registry only.
+- No Ractor support, no lock-free/atomics redesign — a single stdlib `Mutex` is sufficient given registry operations are infrequent relative to the calculation hot path.
+- No change to `calc`, `diff`, `working?`, or `find_weekpattern` — none of these touch `@@workpatterns` (confirmed by reading the full file; they operate only on the instance's own `@weeks`/`@from`/`@to`).
+- No new external dependency — `concurrent-ruby` is only a transitive dependency of `tzinfo` (`Gemfile.lock:9,54`), not declared in the gemspec; adding it as a direct dependency for this fix is unjustified when stdlib `Mutex` is sufficient.
+- No new Rubocop `Style/ClassVars` category introduced — `@@workpatterns` is already a known, currently-flagged offense (`Style/ClassVars`, unexcluded in `.rubocop_todo.yml:438-441` despite the commented-out exclude line) that the team has deliberately deferred (commit `7ba57b4`: "class variables ... require refactoring"). A `@@mutex` class variable is one more instance of the same accepted offense, not a new problem.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `lib/workpattern/workpattern.rb:18-24` — `@@workpatterns` declaration and the existing `self.workpatterns` reader to be changed.
+- `lib/workpattern/workpattern.rb:61-76` — `initialize`: check-then-insert race, and the ordering issue described in Key Technical Decisions below.
+- `lib/workpattern/workpattern.rb:90-120` — `self.clear`, `self.to_a`, `self.get`, `self.delete`: straightforward reads/writes to guard.
+- `lib/workpattern/workpattern.rb:175-213` — `self.from_h`: validation, then the same check-then-insert/overwrite race as `initialize`.
+- `lib/workpattern.rb:92-94` — module-level facade delegating `self.workpatterns` straight to the class method; no change needed here since it only forwards the return value.
+- `test/test_workpattern_module.rb` — existing registry-behavior tests (`test_must_raise_error_when_creating_workpattern_with_existing_name`, `test_must_return_an_array_of_all_known_workpattern_objects`, etc.); each test's `setup` calls `Workpattern.clear`, confirming tests run sequentially with no shared-state teardown hazard for a module-level `Mutex` constant.
+- `test/test_workpattern_serialisation.rb:163` — the one existing caller of `Workpattern.workpatterns` that must keep working against a frozen dup.
+- Style conventions confirmed by reading the file: no `attr_accessor`/`attr_writer` in `lib/`, `public`/`private` used as bare section markers, plain `raise ExceptionClass, "message"` with no custom exception classes — the Mutex addition should follow the same plain-Ruby style with no new abstractions.
+
+### Institutional Learnings
+
+- No `docs/solutions/` directory exists in this repo — no prior learnings to build on for concurrency, class variables, or registry patterns. This is a new category of change for the codebase (the team's recent commits have been readability/rubocop hygiene, not thread-safety work). Worth documenting under `docs/solutions/` after landing, per the project's compounding convention — noted under Documentation / Operational Notes below.
+
+### External References
+
+- None consulted — stdlib `Mutex` usage is well-established Ruby, and the codebase's own conventions (confirmed above) are sufficient to guide a house-style-consistent implementation.
+
+---
+
+## Key Technical Decisions
+
+- **A single global `Mutex` constant, not per-operation or reader/writer locks:** Registry operations (`new`, `get`, `delete`, `clear`, `to_a`, `from_h`) are infrequent relative to the calculation hot path (`calc`/`diff`/`working?` never touch `@@workpatterns`). A single lock adds negligible overhead and avoids the complexity of finer-grained locking for no measurable benefit at this gem's scale.
+- **Hold the lock across the entire check-and-build-and-insert sequence in `initialize` and `from_h`, not just the check+insert:** Splitting the critical section (check name inside the lock, build the `Week`/`WeekPattern` objects outside it, then re-acquire to insert) reopens exactly the TOCTOU race the lock exists to close — a second thread could pass the name check in the gap. Since registry operations are not hot-path, the simplest and only fully-correct option is to hold the lock for the full method body from the name check through the final registry write.
+- **Incidental fix: construct `@week_pattern` before inserting into the registry, not after.** Reading `initialize` closely (`workpattern.rb:74-75`) shows `workpatterns[@name] = self` happens *before* `@week_pattern = WeekPattern.new(self)`. Under the new lock, a concurrent reader could theoretically... no — since the whole method body is now inside the lock, no reader can observe the object mid-construction at all. But since this plan is already touching this exact code (line ordering falls naturally out of designing the critical section), reorder so `@week_pattern` is set before the registry insert, matching the general principle "never publish a partially-constructed object" and removing what would otherwise be a latent single-threaded footgun if the lock boundary is ever narrowed later. Low cost (swap two lines), meaningfully more correct.
+- **Two distinct accessor paths — internal direct access vs. external locked-and-frozen access:** `initialize`, `self.clear`, `self.to_a`, `self.get`, `self.delete`, and `self.from_h` all read/write the registry from *inside* their own `@@mutex.synchronize` block (per the previous decision). None of them may reach the registry through `self.workpatterns` (the public accessor U2 changes) or route through it indirectly, for two independent reasons verified against real Ruby semantics: (1) `Mutex` is not reentrant — a thread calling `@@mutex.synchronize` again while it already holds the lock raises `ThreadError: deadlock; recursive locking` (confirmed with `ruby -e 'm=Mutex.new; m.synchronize{ m.synchronize{} }'`), so every one of the six methods would deadlock on its very first call, not just under contention; (2) once `self.workpatterns` returns a frozen duplicate, any internal write attempted through it (`workpatterns[@name] = self`, `workpatterns.clear`, `workpatterns.delete(name)`, `workpatterns[name] = wp`) raises `FrozenError`. The fix is to give the registry two distinct access paths: inside the six locked methods, read/write the `@@workpatterns` class variable directly (it's already reachable from both class and instance methods of the same class — no accessor call needed); `self.workpatterns` becomes the sole external-facing entry point, used only by callers who are not already holding the lock.
+- **`self.workpatterns` returns `@@workpatterns.dup.freeze`, not the live hash:** A shallow frozen duplicate satisfies the one existing read-only caller (`test/test_workpattern_serialisation.rb:163`, a `.keys.select` call) while making direct mutation attempts raise `FrozenError` instead of silently corrupting the real registry. Values (the `Workpattern` objects themselves) are not frozen — only the hash structure — since nothing requires deep-freezing the workpattern objects themselves. This method is reserved exclusively for external callers per the decision above.
+- **Plain stdlib `Mutex`, not `concurrent-ruby`:** `concurrent-ruby` is present only transitively via `tzinfo` (`Gemfile.lock:9,54`) and is not declared in the gemspec. Adding it as a direct dependency for one `Mutex` is unjustified; stdlib `Mutex` requires no new dependency and matches the gemspec's implicit "no new deps without reason" posture (no dependencies have been added since `tzinfo`/`sorted_set`).
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Lock granularity: single global `Mutex` (see Key Technical Decisions).
+- Critical section boundaries in `initialize`/`from_h`: whole method body, not just check+insert (see Key Technical Decisions).
+- Non-mutable view mechanism: `@@workpatterns.dup.freeze` (see Key Technical Decisions).
+- Accessor split to avoid Mutex re-entrancy and `FrozenError`: internal call sites reference `@@workpatterns` directly; `self.workpatterns` is reserved exclusively for external callers (see Key Technical Decisions, "Two distinct accessor paths" — surfaced during document review, since a naive reading of the original U1/U2 draft would have every internal call site route through the same accessor U2 locks and freezes, deadlocking on the first call).
+
+### Deferred to Implementation
+
+- Exact assertion style for the stress-test unit (thread count, iteration count) is left to the implementer — enough to reliably exercise contention without making the test suite slow. A few dozen threads with a few hundred iterations each is typically sufficient to surface a check-then-act race if one exists; the implementer should tune for a fast, reliable, non-flaky test rather than hit a specific number.
+
+---
+
+## Implementation Units
+
+- U1. **Guard registry mutation and lookup with a single Mutex**
+
+**Goal:** All six registry-touching methods (`initialize`, `self.clear`, `self.to_a`, `self.get`, `self.delete`, `self.from_h`) become mutually exclusive with each other, closing both the check-then-act race and the concurrent-mutation hazard.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `lib/workpattern/workpattern.rb`
+- Test: `test/test_workpattern_module.rb`, `test/test_workpattern_serialisation.rb`
+
+**Approach:**
+- Add a `@@mutex = Mutex.new` class variable near the existing `@@workpatterns = {}` declaration (`workpattern.rb:20`), matching the codebase's existing bare class-variable style (already an accepted, deliberately-deferred Rubocop `Style/ClassVars` offense — see Scope Boundaries).
+- Inside every locked method body below, read and write the registry via the `@@workpatterns` class variable **directly** — never through `self.workpatterns` or the private instance-level `workpatterns` helper (`workpattern.rb:82-84`). Calling `self.workpatterns` from inside an already-held `@@mutex.synchronize` block deadlocks (Ruby's `Mutex` is not reentrant), and after U2 that method also returns a frozen duplicate, so a write through it would raise `FrozenError`. See Key Technical Decisions ("Two distinct accessor paths").
+- Wrap the full body of `initialize` (name-check through registry insert, `workpattern.rb:62-75`) in `@@mutex.synchronize`, checking and inserting via `@@workpatterns` directly, and reordering so `@week_pattern = WeekPattern.new(self)` happens before the registry insert (see Key Technical Decisions).
+- Wrap `self.clear`, `self.to_a`, `self.get`, `self.delete` bodies in `@@mutex.synchronize`, each operating on `@@workpatterns` directly instead of calling `workpatterns`.
+- Wrap the full body of `self.from_h` (name/version/field validation through registry insert or overwrite, `workpattern.rb:175-213`) in `@@mutex.synchronize`, using `@@workpatterns` directly for the existence check, the delete-on-overwrite, and the final insert.
+- Remove or repurpose the private instance method `workpatterns` (`workpattern.rb:82-84`) — with `initialize` now referencing `@@workpatterns` directly, this delegation to `self.class.workpatterns` is no longer needed and would otherwise reintroduce the same deadlock/FrozenError risk if left calling the public accessor.
+- Do not change any method's raised exception types or messages — only add synchronisation around existing logic.
+
+**Patterns to follow:**
+- `lib/workpattern/workpattern.rb` existing bare `raise(NameError, "...")` / `raise ArgumentError, "..."` style — no new exception classes.
+- Existing `public`/`private` bare section markers (`workpattern.rb:80,86`) — keep the Mutex declaration and any newly-private helpers consistent with this.
+
+**Test scenarios:**
+- Happy path: existing single-threaded tests in `test/test_workpattern_module.rb` (create, get, delete, clear, to_a) continue passing unmodified — no behavior change for sequential callers.
+- Edge case: `test_must_raise_error_when_creating_workpattern_with_existing_name` (already exists) continues to pass, confirming the lock doesn't change single-threaded `NameError` behavior.
+- Integration: round-trip `from_h` tests in `test/test_workpattern_serialisation.rb` (overwrite: true/false paths) continue to pass with the full method body now locked.
+
+**Verification:**
+- Full existing test suite passes unchanged (`121 runs, 0 failures, 0 errors` baseline before this plan) — this is the concrete signal that no deadlock or `FrozenError` was introduced, since any nested lock/frozen-write bug would fail every test that creates, clears, deletes, or reloads a workpattern, not just a concurrent one.
+- Grep confirms none of the six locked methods calls `self.workpatterns` or the removed private `workpatterns` helper — all six reference `@@workpatterns` directly.
+- Reading `initialize`, no path exists where a `Workpattern` is inserted into `@@workpatterns` before its `@week_pattern` is set.
+
+---
+
+- U2. **Close the raw-hash leak in `Workpattern.workpatterns`**
+
+**Goal:** `Workpattern.workpatterns` (and the module facade that re-exports it) returns a frozen duplicate rather than the live registry hash, so external callers can no longer bypass U1's synchronisation by mutating the returned object directly.
+
+**Requirements:** R4, R5
+
+**Dependencies:** U1 (touches the same accessor region; land after the Mutex exists so the accessor read itself can also be guarded)
+
+**Files:**
+- Modify: `lib/workpattern/workpattern.rb`
+- Test: `test/test_workpattern_serialisation.rb`
+
+**Approach:**
+- Change `self.workpatterns` (`workpattern.rb:22-24`) to acquire `@@mutex.synchronize` and return `@@workpatterns.dup.freeze` instead of `@@workpatterns` directly.
+- This method is exclusively the external-facing entry point from this point on — per U1's revised Approach, no internal call site inside the six locked methods may call it (doing so would deadlock, since `Mutex` is not reentrant, and after this change would also raise `FrozenError` on any write attempt). U1 removes the private instance method `workpatterns` (`workpattern.rb:82-84`) that previously delegated to this accessor, closing off the one internal call site that would otherwise still reach it.
+- No change needed in `lib/workpattern.rb:92-94` — it only forwards the return value of `Workpattern::Workpattern.workpatterns`, so the frozen-dup change propagates automatically through the facade.
+
+**Test scenarios:**
+- Happy path: `test/test_workpattern_serialisation.rb:163`'s existing `.keys.select` usage continues to pass unmodified against the frozen dup.
+- Covers AE3. Edge case: after `Workpattern.new("readonly-check")`, `h = Workpattern.workpatterns; h["injected"] = 1` raises `FrozenError`, and a subsequent `Workpattern.workpatterns` call does not include `"injected"` — the real registry was unaffected.
+
+**Verification:**
+- `test/test_workpattern_serialisation.rb:163` passes unchanged.
+- A new test confirms mutating the returned hash raises `FrozenError` and leaves the real registry untouched.
+
+---
+
+- U3. **Concurrency stress test**
+
+**Goal:** Demonstrate, under real multi-threaded contention, that the uniqueness guarantee (R3) and mutual-exclusion property (R2) actually hold — not just that the code compiles with a Mutex added.
+
+**Requirements:** R6
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Create or modify: `test/test_workpattern_module.rb` (or a new `test/test_workpattern_registry_concurrency.rb` if the implementer judges the scenarios substantial enough to warrant a dedicated file — either is acceptable; follow the `Minitest::Test` style used throughout `test/`)
+
+**Approach:**
+- Spawn multiple `Thread` instances that concurrently call `Workpattern.new` with a shared, colliding name; assert exactly one succeeds and the rest raise `NameError` (covers AE1).
+- Spawn a mixed workload of threads concurrently calling `.new` (distinct names), `.get`, `.to_a`, `.delete`, and `.clear`; assert no thread raises an unexpected `RuntimeError` (e.g. "can't add a new key into hash during iteration") and the registry ends in an internally consistent state (covers AE2).
+- Use `Thread#join` on all spawned threads before asserting, and re-raise any exception captured from a thread body (Minitest won't see exceptions raised inside a `Thread` unless they're surfaced back to the main thread) — a standard pattern for this kind of test, left to the implementer to express idiomatically.
+
+**Test scenarios:**
+- Covers AE1. Concurrency: 10+ threads simultaneously call `Workpattern.new("contested")` — exactly one succeeds, the other 9 raise `NameError`, and `Workpattern.get("contested")` afterward returns a single valid Workpattern.
+- Covers AE2. Concurrency: a mixed-operation thread pool (create/get/to_a/delete on various names) run for enough iterations to reliably exercise interleaving — no unexpected exception escapes, and post-run registry state has no orphaned or duplicated entries.
+
+**Verification:**
+- The new test(s) fail if U1's `Mutex.synchronize` wrapping is removed (a reasonable manual check during review: temporarily comment out the lock and confirm the stress test now fails or flakes) and pass reliably (non-flaky across repeated runs) with it in place.
+- Full test suite still passes with the new test(s) included.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Only the six registry-touching class methods are affected. `calc`, `diff`, `working?`, and `find_weekpattern` — the calculation hot path — never read or write `@@workpatterns` (confirmed by reading the full file), so no performance-sensitive code path is affected by the new lock.
+- **State lifecycle risks:** The `initialize` reordering (U1) removes the only window where a `Workpattern` could be visible in the registry before being fully constructed. No other partial-construction paths exist (`from_h` already builds the object fully via `instance_variable_set` before inserting).
+- **API surface parity:** `Workpattern.workpatterns` is re-exported unchanged in signature by the module facade (`lib/workpattern.rb:92-94`); only its return value's mutability changes, which is the intended fix (R4).
+- **Unchanged invariants:** `calc`, `diff`, `working?`, `resting`, `working`, `to_h`, `from_h`'s validation/error behavior, and the `NameError`/`ArgumentError` contracts are all untouched — this plan only adds synchronisation and changes one accessor's return value from mutable to frozen.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| A global `Mutex` held across `initialize`'s full body (including `Week.new`/`WeekPattern.new` construction) could, in principle, allow one slow construction to block other unrelated registry reads. | Registry operations are infrequent and construction is fast (no I/O); the origin brainstorm's own Dependencies section confirms this is not a hot path. Acceptable tradeoff for correctness (see Key Technical Decisions). |
+| The stress test (U3) could be flaky if thread scheduling doesn't reliably interleave. | Implementer tunes thread/iteration counts for reliable, repeatable failure-without-the-fix rather than a fixed magic number (see Open Questions — Deferred to Implementation). |
+| Freezing `self.workpatterns`'s return value could break an undiscovered caller beyond the one known test. | Confirmed via repo research: `test/test_workpattern_serialisation.rb:163` is the only external caller found in `lib/`, `test/`, and `README.md`; its usage is read-only (`.keys.select`) and unaffected by freezing. |
+
+---
+
+## Documentation / Operational Notes
+
+- After landing, consider adding a short `docs/solutions/` entry documenting the Mutex approach and the rationale for a frozen-dup accessor over the raw hash — no prior institutional learning exists on concurrency in this codebase (confirmed: no `docs/solutions/` directory exists yet), so this would be the first such entry and a reference point for any future registry changes.
+- No CHANGELOG entry is strictly required for behavior correctness (no public API shape changes), but noting the fix under the next unreleased version section (following the existing `CHANGELOG.md` convention used for the `to_h`/`from_h` work) is reasonable given it closes a real correctness gap for concurrent callers.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-07-24-thread-safe-registry-requirements.md](../brainstorms/2026-07-24-thread-safe-registry-requirements.md)
+- Related code: `lib/workpattern/workpattern.rb`, `lib/workpattern.rb`
+- Related ideation: `docs/ideation/2026-04-26-open-ideation.md` (idea #2 — thread-local proposal, rejected in favor of this approach)

--- a/lib/workpattern.rb
+++ b/lib/workpattern.rb
@@ -87,7 +87,8 @@ module Workpattern
 
   # Convenience method to access the registry of all known Workpattern objects.
   #
-  # @return [Hash]
+  # @return [Hash] a frozen duplicate of the registry -- mutating it (e.g. `[]=`) raises FrozenError.
+  # Use .new, .delete, .clear, or .from_h to change the registry itself.
   #
   def self.workpatterns
     Workpattern.workpatterns

--- a/lib/workpattern/workpattern.rb
+++ b/lib/workpattern/workpattern.rb
@@ -18,9 +18,13 @@ module Workpattern
   class Workpattern
     # Holds collection of <tt>Workpattern</tt> objects
     @@workpatterns = {}
+    @@mutex = Mutex.new
 
+    # Returns a frozen snapshot of the registry. Reserved for external callers;
+    # internal registry methods read/write @@workpatterns directly since they
+    # already hold @@mutex, and Mutex#synchronize is not reentrant.
     def self.workpatterns
-      @@workpatterns
+      @@mutex.synchronize { @@workpatterns.dup.freeze }
     end
 
     # @!attribute [r] name
@@ -59,43 +63,37 @@ module Workpattern
     # @raise [NameError] if the given name already exists
     #
     def initialize(name = DEFAULT_WORKPATTERN_NAME, base = DEFAULT_BASE_YEAR, span = DEFAULT_SPAN)
-      raise(NameError, "Workpattern '#{name}' already exists and can't be created again") if workpatterns.key?(name)
+      @@mutex.synchronize do
+        raise(NameError, "Workpattern '#{name}' already exists and can't be created again") if @@workpatterns.key?(name)
 
-      offset = span.negative? ? span.abs - 1 : 0
+        offset = span.negative? ? span.abs - 1 : 0
 
-      @name = name
-      @base = base
-      @span = span
-      @from = Time.gm(@base.abs - offset)
-      @to = Time.gm(@from.year + @span.abs - 1, 12, 31, 23, 59)
-      @weeks = SortedSet.new
-      @weeks << Week.new(@from, @to)
+        @name = name
+        @base = base
+        @span = span
+        @from = Time.gm(@base.abs - offset)
+        @to = Time.gm(@from.year + @span.abs - 1, 12, 31, 23, 59)
+        @weeks = SortedSet.new
+        @weeks << Week.new(@from, @to)
 
-      workpatterns[@name] = self
-      @week_pattern = WeekPattern.new(self)
+        @week_pattern = WeekPattern.new(self)
+        @@workpatterns[@name] = self
+      end
     end
 
     attr_reader :week_pattern
 
-    private
-
-    def workpatterns
-      self.class.workpatterns
-    end
-
-    public
-
     # Deletes all <tt>Workpattern</tt> objects
     #
     def self.clear
-      workpatterns.clear
+      @@mutex.synchronize { @@workpatterns.clear }
     end
 
     # Returns an Array containing all the <tt>Workpattern</tt> objects
     # @return [Array] all <tt>Workpattern</tt> objects
     #
     def self.to_a
-      workpatterns.to_a
+      @@mutex.synchronize { @@workpatterns.to_a }
     end
 
     # Returns the specific named <tt>Workpattern</tt>
@@ -104,9 +102,11 @@ module Workpattern
     # exist
     #
     def self.get(name)
-      return workpatterns[name] if workpatterns.key?(name)
+      @@mutex.synchronize do
+        return @@workpatterns[name] if @@workpatterns.key?(name)
 
-      raise(NameError, "Workpattern '#{name}' doesn't exist so can't be retrieved")
+        raise(NameError, "Workpattern '#{name}' doesn't exist so can't be retrieved")
+      end
     end
 
     # Deletes the specific named <tt>Workpattern</tt>
@@ -115,8 +115,10 @@ module Workpattern
     # if it doesn't
     #
     def self.delete(name)
-      result = workpatterns.delete(name).nil?
-      !result
+      @@mutex.synchronize do
+        result = @@workpatterns.delete(name).nil?
+        !result
+      end
     end
 
     # Applys a working or resting pattern to the <tt>Workpattern</tt> object.
@@ -187,29 +189,32 @@ module Workpattern
       raise ArgumentError, 'from_h: :weeks must be an Array' unless hash[:weeks].is_a?(Array)
 
       name = hash[:name]
-      raise NameError, "Workpattern '#{name}' already exists and can't be created again" if workpatterns.key?(name) && !overwrite
 
-      wp = allocate
-      wp.instance_variable_set(:@name, name)
-      wp.instance_variable_set(:@base, hash[:base])
-      wp.instance_variable_set(:@span, hash[:span])
+      @@mutex.synchronize do
+        raise NameError, "Workpattern '#{name}' already exists and can't be created again" if @@workpatterns.key?(name) && !overwrite
 
-      offset    = hash[:span].negative? ? hash[:span].abs - 1 : 0
-      from_time = Time.gm(hash[:base].abs - offset)
-      to_time   = Time.gm(from_time.year + hash[:span].abs - 1, 12, 31, 23, 59)
-      wp.instance_variable_set(:@from, from_time)
-      wp.instance_variable_set(:@to,   to_time)
+        wp = allocate
+        wp.instance_variable_set(:@name, name)
+        wp.instance_variable_set(:@base, hash[:base])
+        wp.instance_variable_set(:@span, hash[:span])
 
-      weeks = SortedSet.new
-      hash[:weeks].each { |wh| weeks << Week.from_h(wh) }
-      raise ArgumentError, 'from_h: :weeks must not be empty' if weeks.empty?
+        offset    = hash[:span].negative? ? hash[:span].abs - 1 : 0
+        from_time = Time.gm(hash[:base].abs - offset)
+        to_time   = Time.gm(from_time.year + hash[:span].abs - 1, 12, 31, 23, 59)
+        wp.instance_variable_set(:@from, from_time)
+        wp.instance_variable_set(:@to,   to_time)
 
-      wp.instance_variable_set(:@weeks, weeks)
-      wp.instance_variable_set(:@week_pattern, WeekPattern.new(wp))
+        weeks = SortedSet.new
+        hash[:weeks].each { |wh| weeks << Week.from_h(wh) }
+        raise ArgumentError, 'from_h: :weeks must not be empty' if weeks.empty?
 
-      workpatterns.delete(name) if overwrite
-      workpatterns[name] = wp
-      wp
+        wp.instance_variable_set(:@weeks, weeks)
+        wp.instance_variable_set(:@week_pattern, WeekPattern.new(wp))
+
+        @@workpatterns.delete(name) if overwrite
+        @@workpatterns[name] = wp
+        wp
+      end
     end
 
     # Calculates the resulting date when the <tt>duration</tt> in minutes

--- a/test/test_workpattern_registry_concurrency.rb
+++ b/test/test_workpattern_registry_concurrency.rb
@@ -1,0 +1,106 @@
+require "#{File.dirname(__FILE__)}/test_helper.rb"
+
+class TestWorkpatternRegistryConcurrency < WorkpatternTest # :nodoc:
+  def setup
+    Workpattern.clear
+  end
+
+  # Covers AE1: exactly one of many concurrent creators for the same name
+  # succeeds; the rest raise NameError; the registry ends with one entry.
+  #
+  # Plain thread racing does not reliably interleave under MRI's GVL for a
+  # short, allocation-light method body -- verified empirically: 200 threads
+  # racing Workpattern.new against the pre-fix (unguarded) code produced zero
+  # observed races. GC.stress = true forces a full GC (and therefore a
+  # scheduler checkpoint) on every allocation, which reliably widens the
+  # check-then-insert window enough to expose the race with only a couple of
+  # threads. Confirmed against the pre-fix code: this exact test fails
+  # (more than one thread wins) every time under GC.stress; against the
+  # fixed code it passes every time. Always restore GC.stress in ensure --
+  # it is a process-wide VM setting, not thread- or test-local.
+  def test_concurrent_creation_with_same_name_exactly_one_succeeds
+    name = 'contested'
+    thread_count = 3
+    results = Array.new(thread_count)
+
+    begin
+      GC.stress = true
+      threads = Array.new(thread_count) do |i|
+        Thread.new do
+          results[i] =
+            begin
+              Workpattern.new(name)
+              :created
+            rescue NameError
+              :name_error
+            end
+        end
+      end
+      threads.each(&:join)
+    ensure
+      GC.stress = false
+    end
+
+    assert_equal 1, results.count(:created), 'expected exactly one thread to win the race'
+    assert_equal thread_count - 1, results.count(:name_error), 'expected every other thread to raise NameError'
+    assert_instance_of Workpattern::Workpattern, Workpattern.get(name)
+  end
+
+  # Covers AE2: a mixed workload of creators (distinct names, no collisions),
+  # readers (get/to_a on pre-seeded names), and deleters (idempotent, never
+  # raise) interleaves without any unexpected exception escaping a thread,
+  # and leaves the registry in an internally consistent state.
+  #
+  # Unlike the uniqueness race above, the concurrent-mutation hazard this
+  # guards against (RuntimeError from mutating a Hash mid-iteration) proved
+  # too narrow to force reliably even with GC.stress -- and forcing it across
+  # this many threads made runtime highly variable (seconds to minutes).
+  # This test runs at natural speed as a general interleaving smoke test;
+  # the uniqueness test above is the one that deterministically regresses
+  # without the Mutex.
+  def test_concurrent_mixed_operations_do_not_corrupt_registry
+    seed_names = Array.new(10) { |i| "seed-#{i}" }
+    seed_names.each { |name| Workpattern.new(name) }
+
+    errors = Queue.new
+    threads = []
+
+    30.times do |i|
+      threads << Thread.new do
+        Workpattern.new("created-#{i}")
+      rescue StandardError => e
+        errors << e
+      end
+    end
+
+    10.times do
+      threads << Thread.new do
+        50.times do
+          Workpattern.to_a
+          Workpattern.get(seed_names.sample)
+        end
+      rescue StandardError => e
+        errors << e
+      end
+    end
+
+    30.times do |i|
+      threads << Thread.new do
+        Workpattern.delete("created-#{i}")
+      rescue StandardError => e
+        errors << e
+      end
+    end
+
+    threads.each(&:join)
+
+    leaked = Array.new(errors.size) { errors.pop }
+
+    assert_empty leaked, "unexpected exception(s) escaped a thread: #{leaked.map(&:message)}"
+
+    Workpattern.to_a.each do |name, wp|
+      assert_instance_of Workpattern::Workpattern, wp, "registry entry #{name.inspect} is not a Workpattern"
+      assert_equal name, wp.name, "registry key #{name.inspect} does not match stored workpattern's own name"
+    end
+  end
+end

--- a/test/test_workpattern_registry_concurrency.rb
+++ b/test/test_workpattern_registry_concurrency.rb
@@ -33,6 +33,8 @@ class TestWorkpatternRegistryConcurrency < WorkpatternTest # :nodoc:
               :created
             rescue NameError
               :name_error
+            rescue StandardError => e
+              e
             end
         end
       end
@@ -41,9 +43,51 @@ class TestWorkpatternRegistryConcurrency < WorkpatternTest # :nodoc:
       GC.stress = false
     end
 
+    unexpected = results.grep(Exception)
+
+    assert_empty unexpected, "unexpected exception(s) escaped a thread: #{unexpected.map(&:message)}"
     assert_equal 1, results.count(:created), 'expected exactly one thread to win the race'
     assert_equal thread_count - 1, results.count(:name_error), 'expected every other thread to raise NameError'
     assert_instance_of Workpattern::Workpattern, Workpattern.get(name)
+  end
+
+  # Covers R3 for Workpattern.from_h: the identical check-then-act race exists
+  # at from_h's existence check (lib/workpattern/workpattern.rb) as in
+  # initialize above. Exercised the same way -- multiple threads racing
+  # from_h(hash) for the same name under GC.stress.
+  def test_concurrent_from_h_with_same_name_exactly_one_succeeds
+    template_hash = Workpattern.new('from_h-template').to_h
+    Workpattern.delete('from_h-template')
+    hash = template_hash.merge(name: 'contested-from-h')
+    thread_count = 3
+    results = Array.new(thread_count)
+
+    begin
+      GC.stress = true
+      threads = Array.new(thread_count) do |i|
+        Thread.new do
+          results[i] =
+            begin
+              Workpattern.from_h(hash)
+              :created
+            rescue NameError
+              :name_error
+            rescue StandardError => e
+              e
+            end
+        end
+      end
+      threads.each(&:join)
+    ensure
+      GC.stress = false
+    end
+
+    unexpected = results.grep(Exception)
+
+    assert_empty unexpected, "unexpected exception(s) escaped a thread: #{unexpected.map(&:message)}"
+    assert_equal 1, results.count(:created), 'expected exactly one thread to win the race'
+    assert_equal thread_count - 1, results.count(:name_error), 'expected every other thread to raise NameError'
+    assert_instance_of Workpattern::Workpattern, Workpattern.get('contested-from-h')
   end
 
   # Covers AE2: a mixed workload of creators (distinct names, no collisions),

--- a/test/test_workpattern_serialisation.rb
+++ b/test/test_workpattern_serialisation.rb
@@ -199,4 +199,13 @@ class TestWorkpatternSerialisation < WorkpatternTest
 
     assert_equal wp.working?(t1), wp2.working?(t1)
   end
+
+  # 15. Covers AE3. Workpattern.workpatterns returns a frozen, mutation-safe view
+  def test_workpatterns_returns_frozen_view
+    Workpattern.new('readonly-check')
+    h = Workpattern.workpatterns
+
+    assert_raises(FrozenError) { h['injected'] = 1 }
+    refute_includes Workpattern.workpatterns.keys, 'injected'
+  end
 end


### PR DESCRIPTION
## Summary

`Workpattern`'s class-level named registry (`@@workpatterns`) had no synchronization. Concurrent `Workpattern.new` calls could both pass the duplicate-name check and both insert, silently breaking the uniqueness guarantee. `Workpattern.workpatterns` also handed back the live internal hash, so any caller holding that reference could mutate the registry directly, bypassing any lock entirely.

All six registry-touching methods (`new`, `get`, `delete`, `clear`, `to_a`, `from_h`) now run inside a single `Mutex`, and `Workpattern.workpatterns` returns a frozen duplicate instead of the live hash. No public visibility semantics change: a workpattern created on one thread is still visible to every other thread.

## Design decisions

- **One global `Mutex`, not per-operation locks.** Registry operations are infrequent relative to the calculation hot path (`calc`/`diff`/`working?` never touch the registry), so a single lock adds negligible overhead versus finer-grained locking.
- **Two distinct access paths, not one shared accessor.** Internal call sites read/write `@@workpatterns` directly since they already hold the lock; `Workpattern.workpatterns` (external accessor) is the only method that locks and returns a frozen dup. Sharing one accessor between "already inside the lock" and "not yet inside the lock" callers would deadlock — Ruby's `Mutex` isn't reentrant — and, once frozen, would raise `FrozenError` on every internal write. This surfaced during review as a real defect in an earlier draft and is fixed here.
- **`GC.stress` to force the race in tests.** Plain thread racing doesn't reliably interleave under MRI's GVL for a short, allocation-light method body — 200 threads racing `Workpattern.new` against the pre-fix code produced zero observed collisions. `GC.stress = true` forces a scheduler checkpoint on every allocation, reliably reproducing the race with just 2-3 threads.

## Behavior change

`Workpattern.workpatterns` now returns a frozen duplicate of the registry rather than the live hash. Mutating the returned object raises `FrozenError` instead of silently corrupting the registry. No other public method's signature or error behavior changes.

## Testing

`test/test_workpattern_registry_concurrency.rb` empirically proves the fix: both the `Workpattern.new` and `Workpattern.from_h` uniqueness races fail reliably against the pre-fix code and pass reliably against the fix. The mixed-operation test runs at natural speed as a general interleaving smoke test — the narrower read/mutation hazard it targets proved too costly to force deterministically even under `GC.stress`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Sonnet_5-D97757?logo=claude&logoColor=white)